### PR TITLE
fix: modernize importlib

### DIFF
--- a/hivemind_plugin_manager/__init__.py
+++ b/hivemind_plugin_manager/__init__.py
@@ -2,7 +2,7 @@ import enum
 from typing import Optional, Dict, Any, Union, Type
 
 from ovos_utils.log import LOG
-
+from importlib.metadata import entry_points
 from hivemind_plugin_manager.database import AbstractDB, AbstractRemoteDB
 from hivemind_plugin_manager.protocols import AgentProtocol, BinaryDataHandlerProtocol, NetworkProtocol
 
@@ -89,22 +89,6 @@ class BinaryDataHandlerProtocolFactory:
         return plugin(config=config, hm_protocol=hm_protocol, agent_protocol=agent_protocol)
 
 
-def _iter_entrypoints(plug_type: Optional[str]):
-    """
-    Return an iterator containing all entrypoints of the requested type
-    @param plug_type: entrypoint name to load
-    @return: iterator of all entrypoints
-    """
-    try:
-        from importlib_metadata import entry_points
-        for entry_point in entry_points(group=plug_type):
-            yield entry_point
-    except ImportError:
-        import pkg_resources
-        for entry_point in pkg_resources.iter_entry_points(plug_type):
-            yield entry_point
-
-
 def find_plugins(plug_type: HiveMindPluginTypes = None) -> dict:
     """
     Finds all plugins matching specific entrypoint type.
@@ -123,7 +107,7 @@ def find_plugins(plug_type: HiveMindPluginTypes = None) -> dict:
     else:
         plugs = plug_type
     for plug in plugs:
-        for entry_point in _iter_entrypoints(plug):
+        for entry_point in entry_points(group=plug):
             try:
                 entrypoints[entry_point.name] = entry_point.load()
                 if entry_point.name not in entrypoints:

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -143,7 +143,7 @@ class TestBinaryDataHandlerProtocolFactory(unittest.TestCase):
 
 
 class TestFindPlugins(unittest.TestCase):
-    @patch("hivemind_plugin_manager._iter_entrypoints")
+    @patch("hivemind_plugin_manager.entry_points")
     def test_find_plugins_specific_type(self, mock_iter):
         class _EP:
             name = "fake"
@@ -154,13 +154,13 @@ class TestFindPlugins(unittest.TestCase):
         self.assertIn("fake", result)
         self.assertIs(result["fake"], _FakeLocalDB)
 
-    @patch("hivemind_plugin_manager._iter_entrypoints")
+    @patch("hivemind_plugin_manager.entry_points")
     def test_find_plugins_string_type(self, mock_iter):
         mock_iter.return_value = iter([])
         result = find_plugins("hivemind.database")
         self.assertEqual(result, {})
 
-    @patch("hivemind_plugin_manager._iter_entrypoints")
+    @patch("hivemind_plugin_manager.entry_points")
     def test_find_plugins_no_type_iterates_all(self, mock_iter):
         mock_iter.return_value = iter([])
         result = find_plugins()
@@ -168,7 +168,7 @@ class TestFindPlugins(unittest.TestCase):
         # called once per HiveMindPluginTypes member
         self.assertEqual(mock_iter.call_count, len(HiveMindPluginTypes))
 
-    @patch("hivemind_plugin_manager._iter_entrypoints")
+    @patch("hivemind_plugin_manager.entry_points")
     def test_find_plugins_swallows_load_errors(self, mock_iter):
         find_plugins._errored = []  # reset
 


### PR DESCRIPTION
remove the compat layer for old python versions, use stdlib directly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified plugin entry-point discovery mechanism
  - Switched to the standard library enumeration for entry points
  - Removed legacy fallback path for plugin loading

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JarbasHiveMind/hivemind-plugin-manager/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->