### PR TITLE
feat(client): add pipeline_blacklist field

### DIFF
--- a/hivemind_plugin_manager/database.py
+++ b/hivemind_plugin_manager/database.py
@@ -42,6 +42,7 @@ class Client:
     intent_blacklist: List[str] = field(default_factory=list)
     skill_blacklist: List[str] = field(default_factory=list)
     message_blacklist: List[str] = field(default_factory=list)
+    pipeline_blacklist: List[str] = field(default_factory=list)
     allowed_types: List[str] = field(default_factory=list)
     crypto_key: Optional[str] = None
     password: Optional[str] = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,66 @@
+"""Unit tests for the Client dataclass."""
+
+import json
+import unittest
+
+from hivemind_plugin_manager.database import Client
+
+
+class TestClientPipelineBlacklist(unittest.TestCase):
+    def test_default_is_empty_list(self):
+        c = Client(client_id=1, api_key="k")
+        self.assertEqual(c.pipeline_blacklist, [])
+
+    def test_value_is_preserved(self):
+        c = Client(
+            client_id=1,
+            api_key="k",
+            pipeline_blacklist=["ovos-fallback-pipeline-plugin-low"],
+        )
+        self.assertEqual(
+            c.pipeline_blacklist, ["ovos-fallback-pipeline-plugin-low"]
+        )
+
+    def test_serialize_includes_pipeline_blacklist(self):
+        c = Client(client_id=1, api_key="k", pipeline_blacklist=["a", "b"])
+        data = json.loads(c.serialize())
+        self.assertEqual(data["pipeline_blacklist"], ["a", "b"])
+
+    def test_serialize_default_is_empty_list(self):
+        c = Client(client_id=1, api_key="k")
+        data = json.loads(c.serialize())
+        self.assertIn("pipeline_blacklist", data)
+        self.assertEqual(data["pipeline_blacklist"], [])
+
+    def test_deserialize_roundtrip(self):
+        original = Client(client_id=1, api_key="k", pipeline_blacklist=["x"])
+        restored = Client.deserialize(original.serialize())
+        self.assertEqual(restored.pipeline_blacklist, ["x"])
+        self.assertEqual(restored, original)
+
+    def test_deserialize_legacy_without_field_defaults_to_empty(self):
+        """Old serialized payloads predating pipeline_blacklist must still load."""
+        legacy_payload = json.dumps(
+            {
+                "client_id": 1,
+                "api_key": "k",
+                "name": "n",
+                "intent_blacklist": [],
+                "skill_blacklist": [],
+                "message_blacklist": [],
+                "allowed_types": ["recognizer_loop:utterance"],
+            }
+        )
+        c = Client.deserialize(legacy_payload)
+        self.assertEqual(c.pipeline_blacklist, [])
+
+    def test_getitem_setitem_access(self):
+        """Dict-style access works for the new field (used by some plugins)."""
+        c = Client(client_id=1, api_key="k")
+        self.assertEqual(c["pipeline_blacklist"], [])
+        c["pipeline_blacklist"] = ["y"]
+        self.assertEqual(c.pipeline_blacklist, ["y"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `pipeline_blacklist: List[str]` (default `[]`) to the `Client` dataclass.

## Why

Symmetric to `skill_blacklist` / `intent_blacklist` / `message_blacklist`, but for OVOS pipeline plugins (`ovos-stop-pipeline-plugin-high`, `ovos-fallback-pipeline-plugin-low`, etc.). Lets HiveMind core filter unwanted pipeline matchers out of a client's `session.pipeline` at the boundary, without touching ovos-core or pipeline plugins.

## Scope

- One line in \`hivemind_plugin_manager/database.py\`.
- Serialize / deserialize / equality ride along automatically (dataclass + JSON).
- Backward compatible: old serialized clients without the field deserialize with the default empty list (verified).

## Follow-ups (separate PRs)

- hivemind-sqlite-database: schema column + ALTER TABLE migration.
- hivemind-redis-database: add to attr loop.
- HiveMind-core: enforce the filter in \`_update_blacklist\` + CLI commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added support for a pipeline blacklist setting so users can designate pipelines to exclude from processing; it defaults to an empty list.
  * Blacklist values are preserved across save/load and remain compatible with older configurations that omit the field.
* **Tests**
  * Added tests validating default behavior, preservation, serialization/deserialization, backward compatibility, and config-style access.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JarbasHiveMind/hivemind-plugin-manager/pull/18)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->