### PR TITLE
Add client metadata support

### DIFF
--- a/hivemind_plugin_manager/database.py
+++ b/hivemind_plugin_manager/database.py
@@ -1,10 +1,10 @@
 import abc
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from typing import List, Dict, Union, Any, Optional, Iterable
 
 
-ClientDict = Dict[str, Union[str, int, float, List[str]]]
+ClientDict = Dict[str, Any]
 ClientTypes = Union[None, 'Client',
                     str,  # json
                     ClientDict,  # dict
@@ -48,6 +48,7 @@ class Client:
     can_broadcast: bool = True
     can_escalate: bool = True
     can_propagate: bool = True
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         """
@@ -57,6 +58,8 @@ class Client:
             raise ValueError("client_id should be an integer")
         if not isinstance(self.is_admin, bool):
             raise ValueError("is_admin should be a boolean")
+        if not isinstance(self.metadata, dict):
+            self.metadata = {}
         self.allowed_types = self.allowed_types or ["recognizer_loop:utterance",
                                                     "recognizer_loop:record_begin",
                                                     "recognizer_loop:record_end",
@@ -90,8 +93,21 @@ class Client:
         """
         if isinstance(client_data, str):
             client_data = json.loads(client_data)
-        # TODO filter kwargs with inspect
-        return Client(**client_data)
+        known_fields = {f.name for f in fields(Client)}
+        metadata = client_data.get("metadata")
+        if not isinstance(metadata, dict):
+            metadata = {}
+
+        payload = {
+            key: value
+            for key, value in client_data.items()
+            if key in known_fields and key != "metadata"
+        }
+        for key, value in client_data.items():
+            if key not in known_fields:
+                metadata.setdefault(key, value)
+        payload["metadata"] = metadata
+        return Client(**payload)
 
     def __getitem__(self, item: str) -> Any:
         """

--- a/hivemind_plugin_manager/database.py
+++ b/hivemind_plugin_manager/database.py
@@ -94,9 +94,8 @@ class Client:
         if isinstance(client_data, str):
             client_data = json.loads(client_data)
         known_fields = {f.name for f in fields(Client)}
-        metadata = client_data.get("metadata")
-        if not isinstance(metadata, dict):
-            metadata = {}
+        raw_metadata = client_data.get("metadata")
+        metadata = dict(raw_metadata) if isinstance(raw_metadata, dict) else {}
 
         payload = {
             key: value

--- a/hivemind_plugin_manager/database.py
+++ b/hivemind_plugin_manager/database.py
@@ -153,7 +153,7 @@ class Client:
         """
         try:
             other = cast2client(other)
-        except:
+        except TypeError:
             pass
         if isinstance(other, Client):
             return self.serialize() == other.serialize()


### PR DESCRIPTION
Adds optional `metadata` on `Client`.

This gives plugins a small place for extra client context without adding a new top-level field every time.

`api_key` stays the client identity. Metadata defaults to `{}` and older records with extra fields stay readable.

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `metadata` field to Client for storing flexible, custom key-value data.
  * Improved client data deserialization to safely handle unknown fields by storing them in the metadata field for extensibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JarbasHiveMind/hivemind-plugin-manager/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->