### PR TITLE
refactor+tests: simplify Client.deserialize metadata handling

### DIFF
--- a/hivemind_plugin_manager/database.py
+++ b/hivemind_plugin_manager/database.py
@@ -93,20 +93,17 @@ class Client:
         """
         if isinstance(client_data, str):
             client_data = json.loads(client_data)
-        known_fields = {f.name for f in fields(Client)}
-        raw_metadata = client_data.get("metadata")
+
+        data = dict(client_data)
+        raw_metadata = data.pop("metadata", None)
         metadata = dict(raw_metadata) if isinstance(raw_metadata, dict) else {}
 
-        payload = {
-            key: value
-            for key, value in client_data.items()
-            if key in known_fields and key != "metadata"
-        }
-        for key, value in client_data.items():
-            if key not in known_fields:
-                metadata.setdefault(key, value)
-        payload["metadata"] = metadata
-        return Client(**payload)
+        known = {f.name for f in fields(Client)}
+        extras = {k: data.pop(k) for k in list(data) if k not in known}
+
+        # legacy records: fold unknown top-level keys into metadata,
+        # without overwriting keys the caller set explicitly
+        return Client(**data, metadata={**extras, **metadata})
 
     def __getitem__(self, item: str) -> Any:
         """

--- a/tests/test_client_deserialize.py
+++ b/tests/test_client_deserialize.py
@@ -1,0 +1,73 @@
+import json
+import unittest
+
+from hivemind_plugin_manager.database import Client
+
+
+class TestClientDeserialize(unittest.TestCase):
+    def _base(self, **overrides):
+        data = {"client_id": 1, "name": "alice", "api_key": "k"}
+        data.update(overrides)
+        return data
+
+    def test_plain_record_has_empty_metadata(self):
+        c = Client.deserialize(self._base())
+        self.assertEqual(c.metadata, {})
+
+    def test_json_string_input(self):
+        c = Client.deserialize(json.dumps(self._base()))
+        self.assertEqual(c.name, "alice")
+        self.assertEqual(c.metadata, {})
+
+    def test_explicit_metadata_preserved(self):
+        c = Client.deserialize(self._base(metadata={"region": "eu"}))
+        self.assertEqual(c.metadata, {"region": "eu"})
+
+    def test_legacy_unknown_fields_swept_into_metadata(self):
+        c = Client.deserialize(self._base(weird=42, extra="x"))
+        self.assertEqual(c.metadata, {"weird": 42, "extra": "x"})
+
+    def test_explicit_metadata_wins_over_legacy_collision(self):
+        c = Client.deserialize(
+            self._base(weird=42, metadata={"weird": "explicit"})
+        )
+        self.assertEqual(c.metadata, {"weird": "explicit"})
+
+    def test_legacy_and_explicit_metadata_merge_without_collision(self):
+        c = Client.deserialize(
+            self._base(weird=42, metadata={"other": 1})
+        )
+        self.assertEqual(c.metadata, {"weird": 42, "other": 1})
+
+    def test_non_dict_metadata_coerced_to_empty(self):
+        c = Client.deserialize(self._base(metadata="nope"))
+        self.assertEqual(c.metadata, {})
+
+    def test_none_metadata_coerced_to_empty(self):
+        c = Client.deserialize(self._base(metadata=None))
+        self.assertEqual(c.metadata, {})
+
+    def test_deserialize_does_not_mutate_input(self):
+        payload = self._base(weird=42, metadata={"a": 1})
+        snapshot = json.loads(json.dumps(payload))
+        Client.deserialize(payload)
+        self.assertEqual(payload, snapshot)
+
+    def test_post_init_resets_non_dict_metadata(self):
+        c = Client(client_id=1, name="alice", api_key="k", metadata="bad")
+        self.assertEqual(c.metadata, {})
+
+    def test_roundtrip_serialize_deserialize(self):
+        original = Client(
+            client_id=7,
+            name="bob",
+            api_key="kk",
+            metadata={"tier": "gold", "tags": ["a", "b"]},
+        )
+        restored = Client.deserialize(original.serialize())
+        self.assertEqual(restored, original)
+        self.assertEqual(restored.metadata, {"tier": "gold", "tags": ["a", "b"]})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Stacked on top of #21 (base = `client-metadata`). Merge #21 first; this PR's diff will then collapse to just the refactor + tests.

## Refactor
Same behavior, easier to read. Pops `metadata` out, partitions extras with one comprehension, merges via dict-unpack so precedence is visible at the call site instead of hidden in `setdefault`.

Before #21 landed:
- parallel `payload` dict had to stay in sync with the original
- two passes over `client_data.items()`
- `setdefault` carried the legacy-vs-explicit precedence rule implicitly

After this PR:
- one `dict(...)` mutated via `pop`
- one comprehension for extras
- `{**extras, **metadata}` makes "explicit metadata wins over stray legacy keys" obvious

## Tests
New `tests/test_client_deserialize.py` — 11 cases:
- plain record → empty metadata
- JSON-string input
- explicit metadata preserved
- legacy unknown fields swept into metadata
- explicit metadata wins on key collision with legacy
- legacy + explicit metadata merge without collision
- non-dict / `None` metadata coerced to `{}`
- `__post_init__` guards against non-dict metadata on direct construction
- `deserialize` does not mutate its input dict
- serialize/deserialize roundtrip preserves metadata

Run: `python -m unittest discover -s tests -v` → 11 passed.