### PR TITLE
ci: adopt shared OpenVoiceOS/gh-automations workflows

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+source = hivemind_plugin_manager
+omit =
+    hivemind_plugin_manager/tui.py
+    hivemind_plugin_manager/version.py
+
+[report]
+exclude_lines =
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+    \.\.\.
+    pass

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -1,25 +1,14 @@
-name: Run Build Tests
+name: Build Tests
+
 on:
-  push:
+  pull_request:
+    branches: [dev, master]
   workflow_dispatch:
 
 jobs:
-  build_tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.8
-      - name: Install Build Tools
-        run: |
-          python -m pip install build wheel
-      - name: Build Distribution Packages
-        run: |
-          python setup.py bdist_wheel
-      - name: Install package
-        run: |
-          pip install .
+  build:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/build-tests.yml@dev
+    with:
+      python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+      install_extras: 'test'
+      test_path: 'tests'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,16 @@
+name: Code Coverage
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/coverage.yml@dev
+    with:
+      python_version: '3.11'
+      coverage_source: 'hivemind_plugin_manager'
+      test_path: 'tests/'
+      install_extras: ''
+      min_coverage: 0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,4 +13,4 @@ jobs:
       coverage_source: 'hivemind_plugin_manager'
       test_path: 'tests/'
       install_extras: ''
-      min_coverage: 0
+      min_coverage: 70

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -1,0 +1,10 @@
+name: License Check
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  license_check:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/license-check.yml@dev

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,13 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [dev, master]
+  workflow_dispatch:
+
+jobs:
+  lint:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/lint.yml@dev
+    with:
+      ruff: true
+      pre_commit: false

--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -1,0 +1,10 @@
+name: PIP Audit
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  pip_audit:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/pip-audit.yml@dev

--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -1,58 +1,23 @@
-name: Stable Release
+name: Publish Stable Release
+
 on:
+  workflow_dispatch:
   push:
     branches: [master]
-  workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   publish_stable:
-    uses: TigreGotico/gh-automations/.github/workflows/publish-stable.yml@master
-    secrets: inherit
+    if: github.actor != 'github-actions[bot]'
+    uses: OpenVoiceOS/gh-automations/.github/workflows/publish-stable.yml@dev
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      MATRIX_TOKEN: ${{ secrets.MATRIX_TOKEN }}
     with:
-      branch: 'master'
       version_file: 'hivemind_plugin_manager/version.py'
-      setup_py: 'setup.py'
+      publish_pypi: true
       publish_release: true
-
-  publish_pypi:
-    needs: publish_stable
-    if: success()  # Ensure this job only runs if the previous job succeeds
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: dev
-          fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.8
-      - name: Install Build Tools
-        run: |
-          python -m pip install build wheel
-      - name: version
-        run: echo "::set-output name=version::$(python setup.py --version)"
-        id: version
-      - name: Build Distribution Packages
-        run: |
-          python setup.py sdist bdist_wheel
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          password: ${{secrets.PYPI_TOKEN}}
-
-
-  sync_dev:
-    needs: publish_stable
-    if: success()  # Ensure this job only runs if the previous job succeeds
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
-          ref: master
-      - name: Push master -> dev
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: dev
+      sync_dev: true
+      notify_matrix: true

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -1,0 +1,13 @@
+name: Release Preview
+
+on:
+  pull_request:
+    branches: [dev]
+  workflow_dispatch:
+
+jobs:
+  release_preview:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/release-preview.yml@dev
+    with:
+      package_name: 'hivemind_plugin_manager'
+      version_file: 'hivemind_plugin_manager/version.py'

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -1,108 +1,28 @@
 name: Release Alpha and Propose Stable
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [closed]
     branches: [dev]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   publish_alpha:
-    if: github.event.pull_request.merged == true
-    uses: TigreGotico/gh-automations/.github/workflows/publish-alpha.yml@master
-    secrets: inherit
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    uses: OpenVoiceOS/gh-automations/.github/workflows/publish-alpha.yml@dev
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      MATRIX_TOKEN: ${{ secrets.MATRIX_TOKEN }}
     with:
       branch: 'dev'
       version_file: 'hivemind_plugin_manager/version.py'
-      setup_py: 'setup.py'
       update_changelog: true
       publish_prerelease: true
-      changelog_max_issues: 100
-
-  notify:
-    if: github.event.pull_request.merged == true
-    needs: publish_alpha
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Send message to Matrix bots channel
-        id: matrix-chat-message
-        uses: fadenb/matrix-chat-message@v0.0.6
-        with:
-          homeserver: 'matrix.org'
-          token: ${{ secrets.MATRIX_TOKEN }}
-          channel: '!jImYhOcJWVpvCRsDjc:matrix.org'
-          message: |
-            new ${{ github.event.repository.name }} PR merged! https://github.com/${{ github.repository }}/pull/${{ github.event.number }}
-
-  publish_pypi:
-    needs: publish_alpha
-    if: success()  # Ensure this job only runs if the previous job succeeds
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: dev
-          fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.8
-      - name: Install Build Tools
-        run: |
-          python -m pip install build wheel
-      - name: version
-        run: echo "::set-output name=version::$(python setup.py --version)"
-        id: version
-      - name: Build Distribution Packages
-        run: |
-          python setup.py sdist bdist_wheel
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          password: ${{secrets.PYPI_TOKEN}}
-
-
-  propose_release:
-    needs: publish_alpha
-    if: success()  # Ensure this job only runs if the previous job succeeds
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout dev branch
-        uses: actions/checkout@v3
-        with:
-          ref: dev
-
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.10'
-
-      - name: Get version from setup.py
-        id: get_version
-        run: |
-          VERSION=$(python setup.py --version)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-
-      - name: Create and push new branch
-        run: |
-          git checkout -b release-${{ env.VERSION }}
-          git push origin release-${{ env.VERSION }}
-
-      - name: Open Pull Request from dev to master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Variables
-          BRANCH_NAME="release-${{ env.VERSION }}"
-          BASE_BRANCH="master"
-          HEAD_BRANCH="release-${{ env.VERSION }}"
-          PR_TITLE="Release ${{ env.VERSION }}"
-          PR_BODY="Human review requested!"
-
-          # Create a PR using GitHub API
-          curl -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -d "{\"title\":\"$PR_TITLE\",\"body\":\"$PR_BODY\",\"head\":\"$HEAD_BRANCH\",\"base\":\"$BASE_BRANCH\"}" \
-            https://api.github.com/repos/${{ github.repository }}/pulls
-
+      propose_release: true
+      changelog_max_issues: 50
+      publish_pypi: true
+      notify_matrix: true

--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -1,0 +1,12 @@
+name: Repo Health
+
+on:
+  pull_request:
+    branches: [dev, master]
+  workflow_dispatch:
+
+jobs:
+  repo_health:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/repo-health.yml@dev
+    with:
+      version_file: 'hivemind_plugin_manager/version.py'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # HiveMind Plugin Manager
 
+> **Full documentation:** [docs/README.md](docs/README.md)
+> — [Getting Started](docs/getting-started.md)
+> | [Concepts](docs/concepts.md)
+> | [API Reference](docs/api-reference.md)
+> | [Contributing](docs/contributing.md)
+
 The **HiveMind Plugin Manager (HPM)** is a system for discovering, managing, and loading plugins within the HiveMind ecosystem. It supports various plugin types, including databases, network protocols, agent protocols, and binary data handlers. HPM allows for dynamic integration of these plugins to enhance the functionality of HiveMind agents, offering a flexible and extensible architecture.
 
 ## Features

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,42 @@
+# HiveMind Plugin Manager — Documentation
+
+HiveMind Plugin Manager (HPM) is the extension point system for the HiveMind ecosystem.
+It defines four plugin types (database, agent protocol, network protocol, binary protocol),
+discovers implementations registered via setuptools entry points, and provides factory classes
+for instantiation.
+
+---
+
+## Who Should Read What
+
+| You want to... | Start here |
+|---|---|
+| Install HPM and understand what it does | [Getting Started](getting-started.md) |
+| Learn the concepts (plugin types, factories, lifecycle) | [Concepts](concepts.md) |
+| Write a database plugin | [Database Plugin Guide](plugins/database.md) |
+| Write an agent protocol plugin | [Agent Protocol Plugin Guide](plugins/agent-protocol.md) |
+| Write a network protocol plugin | [Network Protocol Plugin Guide](plugins/network-protocol.md) |
+| Write a binary data handler plugin | [Binary Protocol Plugin Guide](plugins/binary-protocol.md) |
+| Look up every public class and function | [API Reference](api-reference.md) |
+| Understand internals, error handling, identity, factory routing | [Advanced](advanced.md) |
+| Contribute to this package | [Contributing](contributing.md) |
+
+---
+
+## Key Classes at a Glance
+
+| Class | Plugin type | Source |
+|---|---|---|
+| `HiveMindPluginTypes` | enum of entry-point group names | `hivemind_plugin_manager/__init__.py:10` |
+| `DatabaseFactory` | creates `AbstractDB` / `AbstractRemoteDB` instances | `hivemind_plugin_manager/__init__.py:17` |
+| `AgentProtocolFactory` | creates `AgentProtocol` instances | `hivemind_plugin_manager/__init__.py:38` |
+| `NetworkProtocolFactory` | creates `NetworkProtocol` instances | `hivemind_plugin_manager/__init__.py:56` |
+| `BinaryDataHandlerProtocolFactory` | creates `BinaryDataHandlerProtocol` instances | `hivemind_plugin_manager/__init__.py:73` |
+| `find_plugins()` | discovers all installed plugins for a type | `hivemind_plugin_manager/__init__.py:108` |
+| `Client` | dataclass representing a connected device/credential | `hivemind_plugin_manager/database.py:35` |
+| `AbstractDB` | base class for local database plugins | `hivemind_plugin_manager/database.py:158` |
+| `AbstractRemoteDB` | base class for remote database plugins | `hivemind_plugin_manager/database.py:266` |
+| `AgentProtocol` | base class for agent protocol plugins | `hivemind_plugin_manager/protocols.py:61` |
+| `NetworkProtocol` | base class for network protocol plugins | `hivemind_plugin_manager/protocols.py:70` |
+| `BinaryDataHandlerProtocol` | base class for binary protocol plugins | `hivemind_plugin_manager/protocols.py:88` |
+| `ClientCallbacks` | dataclass of lifecycle hooks | `hivemind_plugin_manager/protocols.py:27` |

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,171 @@
+# Advanced Topics
+
+## Internals of `find_plugins`
+
+```python
+def find_plugins(plug_type: HiveMindPluginTypes = None) -> dict:
+```
+
+Source: `hivemind_plugin_manager/__init__.py:108`
+
+### Entry-point iteration
+
+`_iter_entrypoints(plug_type)` (`__init__.py:92`) tries `importlib_metadata.entry_points`
+first. If `importlib_metadata` is not installed it falls back to
+`pkg_resources.iter_entry_points`. This keeps HPM compatible with older Python environments
+where `importlib.metadata` is absent or incomplete.
+
+### Error swallowing
+
+When an entry point's `.load()` raises any exception:
+
+1. The entry point is appended to `find_plugins._errored` (a module-level list initialised
+   to `[]` at `__init__.py:140`).
+2. `LOG.error` is called **once** for that entry point.
+3. On subsequent calls the entry point is silently skipped (it stays in `_errored`).
+
+This prevents log spam when `find_plugins` is called repeatedly in a tight loop (e.g. from
+a skills manager). The trade-off is that a broken plugin is invisible after the first
+error. If you are debugging a missing plugin, reset the list:
+
+```python
+from hivemind_plugin_manager import find_plugins
+find_plugins._errored = []
+result = find_plugins()   # errors will surface again
+```
+
+### No caching
+
+`find_plugins` does **not** cache results. Every call re-iterates entry points. For
+performance-sensitive startup code, call it once and hold the returned dict.
+
+---
+
+## How `DatabaseFactory` Routes Local vs Remote
+
+```python
+if issubclass(plugin, AbstractRemoteDB):
+    return plugin(name=name, subfolder=subfolder, password=password, host=host, port=port)
+return plugin(name=name, subfolder=subfolder, password=password)
+```
+
+Source: `hivemind_plugin_manager/__init__.py:33`
+
+The factory uses `issubclass` against `AbstractRemoteDB` at instantiation time. This means:
+
+- Callers can always pass `host` and `port` — they are silently dropped for local plugins.
+- A plugin that subclasses `AbstractRemoteDB` but ignores `host`/`port` in its own
+  `__init__` is fine; the values are passed as kwargs and Python discards them if the
+  signature includes `**kwargs` or if the dataclass field is declared with a default.
+- A plugin that subclasses `AbstractDB` directly but needs a host must override
+  `__post_init__` and read from `self.config` or environment variables instead.
+
+---
+
+## Identity and `NodeIdentity`
+
+All protocol base classes expose an `.identity` property via `_SubProtocol`:
+
+```python
+@property
+def identity(self) -> NodeIdentity:
+    if not self.hm_protocol:
+        return NodeIdentity()
+    return self.hm_protocol.identity
+```
+
+Source: `hivemind_plugin_manager/protocols.py:41`
+
+`NodeIdentity` comes from `hivemind-bus-client`. It holds the cryptographic identity (key
+pair, name, UUID) of the current HiveMind node. A fresh `NodeIdentity()` is returned when
+the protocol is not yet attached to a `HiveMindListenerProtocol` — this is the expected
+state during unit tests and during early construction.
+
+---
+
+## The `hm_protocol` Circular Reference
+
+When `hivemind-core` constructs a `HiveMindListenerProtocol` it accepts an
+`agent_protocol` and a `binary_protocol` as constructor arguments. At that point
+`hm_protocol` on both sub-protocols is `None`. After `HiveMindListenerProtocol.__init__`
+runs, it assigns `self` back:
+
+```python
+# pseudocode from hivemind-core (not in this package)
+self.agent_protocol.hm_protocol = self
+self.binary_protocol.hm_protocol = self
+```
+
+This is why the protocols' `_SubProtocol` property helpers always guard with
+`if not self.hm_protocol`. Plugin code that calls `self.database` or `self.clients` during
+`__post_init__` will get `None` / `{}` — this is expected. Access them in handler methods
+that are called after construction.
+
+The comment in the source is explicit:
+
+```
+# usually AgentProtocol is passed as kwarg to hm_protocol
+# and only then assigned in hm_protocol.__post_init__
+```
+
+Source: `hivemind_plugin_manager/protocols.py:65`
+
+---
+
+## `delete_item` Tombstone and `client_id` Reuse
+
+`AbstractDB.delete_item` replaces a client's `api_key` with `"revoked"` rather than
+removing the row:
+
+```python
+client = Client(client_id=client.client_id, api_key="revoked")
+return self.update_item(client)
+```
+
+Source: `hivemind_plugin_manager/database.py:192`
+
+The comment in the source explains the intent:
+
+```
+# leave the deleted entry in db, do not allow reuse of client_id !
+```
+
+When writing a database plugin you must honour this: your `add_item` must handle an
+upsert (update-on-same-`client_id`) rather than always inserting. The test suite
+verifies this behaviour at `tests/test_database.py:185`.
+
+---
+
+## Version Compatibility
+
+HPM declares no version constraints on its plugin implementations. The entry-point contract
+is purely structural: a class that subclasses the right abstract base and implements the
+required methods is a valid plugin. HPM does not check class hierarchies at discovery
+time — it only calls `entry_point.load()`. Type-safety is the plugin author's
+responsibility.
+
+The `_iter_entrypoints` fallback (`__init__.py:92`) ensures compatibility across Python
+3.8+ environments where `importlib.metadata` behaviour differs.
+
+---
+
+## `allowed_types` Default Set
+
+When a `Client` is created with an empty `allowed_types`, `__post_init__` populates it with:
+
+```python
+["recognizer_loop:utterance",
+ "recognizer_loop:record_begin",
+ "recognizer_loop:record_end",
+ "recognizer_loop:audio_output_start",
+ "recognizer_loop:audio_output_end",
+ "recognizer_loop:b64_transcribe",
+ "speak:b64_audio",
+ "ovos.common_play.SEI.get.response"]
+```
+
+Source: `hivemind_plugin_manager/database.py:60`
+
+Additionally, `"recognizer_loop:utterance"` is always appended even when the caller
+provides a custom list (`database.py:68`). This ensures satellite devices can always send
+utterances regardless of how `allowed_types` was configured.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,295 @@
+# API Reference
+
+All public symbols exported from `hivemind_plugin_manager`.
+
+---
+
+## `hivemind_plugin_manager/__init__.py`
+
+### `HiveMindPluginTypes`
+
+```python
+class HiveMindPluginTypes(str, enum.Enum):
+    DATABASE         = "hivemind.database"           # line 11
+    NETWORK_PROTOCOL = "hivemind.network.protocol"   # line 12
+    AGENT_PROTOCOL   = "hivemind.agent.protocol"     # line 13
+    BINARY_PROTOCOL  = "hivemind.binary.protocol"    # line 14
+```
+
+Source: `hivemind_plugin_manager/__init__.py:10`
+
+Each value is the setuptools entry-point group string used for plugin discovery.
+
+---
+
+### `find_plugins(plug_type=None) -> dict`
+
+Source: `hivemind_plugin_manager/__init__.py:108`
+
+Discovers all installed plugins matching `plug_type`.
+
+| Argument | Type | Behaviour |
+|---|---|---|
+| `None` | — | iterates all four `HiveMindPluginTypes` groups, merges results |
+| `HiveMindPluginTypes` member | enum | iterates that one group |
+| `str` | raw entry-point group name | iterates that group |
+
+Returns `{plugin_name: class}`.
+
+Entry-point load failures are caught, logged once, and skipped. Already-errored entry
+points are stored in `find_plugins._errored` (a module-level list) to suppress repeated
+log noise. Source: `hivemind_plugin_manager/__init__.py:132`
+
+---
+
+### `DatabaseFactory`
+
+Source: `hivemind_plugin_manager/__init__.py:17`
+
+#### `DatabaseFactory.get_class(plugin_name: str) -> Type[AbstractDB]`
+
+Returns the class registered under `plugin_name` in `hivemind.database`.
+Raises `KeyError` if not found. Source: `__init__.py:19`
+
+#### `DatabaseFactory.create(plugin_name, name="clients", subfolder="hivemind-core", password=None, host=None, port=None) -> Union[AbstractDB, AbstractRemoteDB]`
+
+Instantiates the plugin. If the class is a subclass of `AbstractRemoteDB`, `host` and
+`port` are forwarded; otherwise they are dropped. Source: `__init__.py:26`
+
+---
+
+### `AgentProtocolFactory`
+
+Source: `hivemind_plugin_manager/__init__.py:38`
+
+#### `AgentProtocolFactory.get_class(plugin_name: str) -> Type[AgentProtocol]`
+
+Raises `KeyError` if not found. Source: `__init__.py:40`
+
+#### `AgentProtocolFactory.create(plugin_name, config=None, bus=None, hm_protocol=None) -> AgentProtocol`
+
+`config` defaults to `{}` when `None`. Source: `__init__.py:47`
+
+---
+
+### `NetworkProtocolFactory`
+
+Source: `hivemind_plugin_manager/__init__.py:56`
+
+#### `NetworkProtocolFactory.get_class(plugin_name: str) -> Type[NetworkProtocol]`
+
+Raises `KeyError` if not found. Source: `__init__.py:58`
+
+#### `NetworkProtocolFactory.create(plugin_name, config=None, hm_protocol=None) -> NetworkProtocol`
+
+`config` defaults to `{}` when `None`. Source: `__init__.py:64`
+
+---
+
+### `BinaryDataHandlerProtocolFactory`
+
+Source: `hivemind_plugin_manager/__init__.py:73`
+
+#### `BinaryDataHandlerProtocolFactory.get_class(plugin_name: str) -> Type[BinaryDataHandlerProtocol]`
+
+Raises `KeyError` if not found. Source: `__init__.py:76`
+
+#### `BinaryDataHandlerProtocolFactory.create(plugin_name, config=None, hm_protocol=None, agent_protocol=None) -> BinaryDataHandlerProtocol`
+
+`config` defaults to `{}` when `None`. Source: `__init__.py:83`
+
+---
+
+## `hivemind_plugin_manager/database.py`
+
+### `Client`
+
+Source: `hivemind_plugin_manager/database.py:35`
+
+```python
+@dataclass
+class Client:
+    client_id: int           # required; must be int
+    api_key: str             # required
+    name: str = ""
+    description: str = ""
+    is_admin: bool = False   # must be bool
+    last_seen: float = -1
+    intent_blacklist: List[str] = field(default_factory=list)
+    skill_blacklist: List[str] = field(default_factory=list)
+    message_blacklist: List[str] = field(default_factory=list)
+    allowed_types: List[str] = field(default_factory=list)
+    crypto_key: Optional[str] = None
+    password: Optional[str] = None
+    can_broadcast: bool = True
+    can_escalate: bool = True
+    can_propagate: bool = True
+```
+
+`__post_init__` (`database.py:52`) enforces int/bool types and populates `allowed_types`
+with a default OVOS message type set. `"recognizer_loop:utterance"` is always present.
+
+| Method | Signature | Source |
+|---|---|---|
+| `serialize()` | `-> str` (JSON) | `database.py:71` |
+| `deserialize(data)` | `staticmethod(str | dict) -> Client` | `database.py:81` |
+| `__getitem__(key)` | `-> Any`; raises `KeyError` | `database.py:96` |
+| `__setitem__(key, val)` | raises `ValueError` on unknown key | `database.py:113` |
+| `__eq__(other)` | compares serialized JSON | `database.py:129` |
+| `__repr__()` | returns `serialize()` | `database.py:147` |
+
+---
+
+### `cast2client(ret: ClientTypes) -> Optional[Union[Client, List[Client]]]`
+
+Source: `hivemind_plugin_manager/database.py:15`
+
+Normalises `None`, `Client`, JSON string, dict, or list into `Client` instances. Raises
+`TypeError` for unsupported types.
+
+---
+
+### `AbstractDB`
+
+Source: `hivemind_plugin_manager/database.py:158`
+
+```python
+@dataclass
+class AbstractDB(abc.ABC):
+    name: str = "clients"
+    subfolder: str = "hivemind-core"
+    password: Optional[str] = None
+```
+
+| Method | Abstract | Signature | Source |
+|---|---|---|---|
+| `add_item` | yes | `(client: Client) -> bool` | `database.py:169` |
+| `search_by_value` | yes | `(key: str, val) -> List[Client]` | `database.py:221` |
+| `__len__` | yes | `() -> int` | `database.py:234` |
+| `__iter__` | yes | `() -> Iterable[Client]` | `database.py:243` |
+| `delete_item` | no | `(client) -> bool` — tombstone pattern | `database.py:181` |
+| `update_item` | no | `(client) -> bool` — calls `add_item` | `database.py:195` |
+| `replace_item` | no | `(old, new) -> bool` | `database.py:207` |
+| `sync` | no | `()` — no-op | `database.py:252` |
+| `commit` | no | `() -> True` | `database.py:256` |
+
+---
+
+### `AbstractRemoteDB`
+
+Source: `hivemind_plugin_manager/database.py:266`
+
+Extends `AbstractDB` with:
+
+```python
+host: str = "127.0.0.1"
+port: Optional[int] = None
+```
+
+Re-declares `add_item`, `search_by_value`, `__len__`, `__iter__` as abstract.
+
+---
+
+## `hivemind_plugin_manager/protocols.py`
+
+### Module-level default callbacks
+
+| Function | Signature | Behaviour | Source |
+|---|---|---|---|
+| `on_disconnect` | `(client) -> None` | logs debug | `protocols.py:13` |
+| `on_connect` | `(client) -> None` | logs debug | `protocols.py:16` |
+| `on_invalid_key` | `(client) -> None` | logs debug | `protocols.py:19` |
+| `on_invalid_protocol` | `(client) -> None` | logs debug | `protocols.py:22` |
+
+---
+
+### `ClientCallbacks`
+
+Source: `hivemind_plugin_manager/protocols.py:27`
+
+```python
+@dataclass
+class ClientCallbacks:
+    on_connect:          Callable[['HiveMindClientConnection'], None] = on_connect
+    on_disconnect:       Callable[['HiveMindClientConnection'], None] = on_disconnect
+    on_invalid_key:      Callable[['HiveMindClientConnection'], None] = on_invalid_key
+    on_invalid_protocol: Callable[['HiveMindClientConnection'], None] = on_invalid_protocol
+```
+
+Defaults to the module-level no-op functions above.
+
+---
+
+### `_SubProtocol`
+
+Source: `hivemind_plugin_manager/protocols.py:35`
+
+Internal base dataclass. All three public protocol classes inherit from it.
+
+Fields: `config: dict`, `hm_protocol: Optional[HiveMindListenerProtocol]`,
+`callbacks: ClientCallbacks`.
+
+Properties:
+
+| Property | Returns | Source |
+|---|---|---|
+| `identity` | `hm_protocol.identity` or fresh `NodeIdentity()` | `protocols.py:41` |
+| `database` | `hm_protocol.db` or `None` | `protocols.py:46` |
+| `clients` | `hm_protocol.clients` or `{}` | `protocols.py:52` |
+
+---
+
+### `AgentProtocol`
+
+Source: `hivemind_plugin_manager/protocols.py:61`
+
+Fields: inherits `_SubProtocol` fields plus `bus: Union[FakeBus, MessageBusClient]`.
+
+No abstract methods. Subclasses add their own message-handling methods.
+
+---
+
+### `NetworkProtocol`
+
+Source: `hivemind_plugin_manager/protocols.py:70`
+
+Additional property:
+
+| Property | Returns | Source |
+|---|---|---|
+| `agent_protocol` | `hm_protocol.agent_protocol` or `None` | `protocols.py:77` |
+
+Abstract method: `run(self)` — must block while serving. Source: `protocols.py:82`
+
+---
+
+### `BinaryDataHandlerProtocol`
+
+Source: `hivemind_plugin_manager/protocols.py:88`
+
+Additional field: `agent_protocol: Optional[AgentProtocol]`.
+
+`__post_init__` (`protocols.py:96`) auto-populates `agent_protocol` from `hm_protocol` if
+not provided explicitly.
+
+All handler methods are concrete no-ops (log a warning). See
+[Binary Protocol Plugin Guide](plugins/binary-protocol.md#handler-methods) for the full
+list with signatures.
+
+---
+
+## `hivemind_plugin_manager/tui.py`
+
+CLI entry point registered as `hpm` console script (`setup.py:54`).
+
+| Command | Usage | Source |
+|---|---|---|
+| `hpm list <type>` | print installed plugins as JSON | `tui.py:84` |
+| `hpm set <type> <name>` | write chosen plugin to `server.json` | `tui.py:97` |
+| `hpm get <type>` | show currently configured plugin | `tui.py:117` |
+| `hpm show-config` | dump full `server.json` | `tui.py:132` |
+
+`<type>` accepts: `network`, `agent`, `binary`, `database`.
+
+Config file: `~/.config/hivemind-core/server.json` (XDG).
+`get_server_config()` — `tui.py:54` — creates the file with defaults on first run.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,171 @@
+# Concepts
+
+## Plugin Types
+
+HPM defines four plugin types as string-valued enum members.
+
+```python
+class HiveMindPluginTypes(str, enum.Enum):
+    DATABASE         = "hivemind.database"
+    NETWORK_PROTOCOL = "hivemind.network.protocol"
+    AGENT_PROTOCOL   = "hivemind.agent.protocol"
+    BINARY_PROTOCOL  = "hivemind.binary.protocol"
+```
+
+Source: `hivemind_plugin_manager/__init__.py:10`
+
+Each value is the setuptools entry-point group name that plugin packages must use.
+
+---
+
+## Entry Points
+
+Plugins are ordinary Python packages. The only contract with HPM is a single line in the
+package's `setup.py` (or `pyproject.toml`):
+
+```ini
+# pyproject.toml
+[project.entry-points."hivemind.database"]
+hivemind-json-db-plugin = "json_database.hpm:JsonDB"
+```
+
+or in `setup.py`:
+
+```python
+entry_points={
+    "hivemind.database": [
+        "hivemind-json-db-plugin = json_database.hpm:JsonDB"
+    ]
+}
+```
+
+The left-hand side of the `=` is the **plugin name** — the string callers pass to factories.
+The right-hand side is the dotted import path to the class.
+
+HPM itself does not ship any plugin implementation. It only defines the abstractions and
+discovers whatever packages are installed in the current Python environment.
+
+---
+
+## Discovery: `find_plugins()`
+
+```python
+def find_plugins(plug_type: HiveMindPluginTypes = None) -> dict:
+```
+
+Source: `hivemind_plugin_manager/__init__.py:108`
+
+`find_plugins` calls `_iter_entrypoints` (`__init__.py:92`) which tries
+`importlib_metadata.entry_points` first and falls back to `pkg_resources` if
+`importlib_metadata` is not available.
+
+Return value is `{plugin_name: class}`.
+
+Key behaviours:
+
+- Passing `None` iterates **all four** entry-point groups and merges the results.
+- Passing a string (e.g. `"hivemind.database"`) is also accepted.
+- If a plugin's `load()` raises, the error is logged once and the entry point is skipped;
+  the dict simply will not contain that name. This is the **error-swallowing** behaviour
+  described in [Advanced](advanced.md).
+- Already-errored entry points are tracked in `find_plugins._errored` to prevent log spam
+  on repeated calls.
+
+---
+
+## Factories
+
+Each plugin type has a corresponding factory with two class methods:
+
+| Factory | `get_class(name)` returns | `create(name, ...)` returns |
+|---|---|---|
+| `DatabaseFactory` | `Type[AbstractDB]` | `AbstractDB` or `AbstractRemoteDB` |
+| `AgentProtocolFactory` | `Type[AgentProtocol]` | `AgentProtocol` |
+| `NetworkProtocolFactory` | `Type[NetworkProtocol]` | `NetworkProtocol` |
+| `BinaryDataHandlerProtocolFactory` | `Type[BinaryDataHandlerProtocol]` | `BinaryDataHandlerProtocol` |
+
+Source: `hivemind_plugin_manager/__init__.py:17–89`
+
+`get_class` raises `KeyError` with a helpful message listing available plugins when the
+requested name is not installed. `create` calls `get_class` then instantiates with the
+appropriate kwargs.
+
+### DatabaseFactory routing
+
+`DatabaseFactory.create` checks whether the resolved class is a subclass of
+`AbstractRemoteDB`. If it is, `host` and `port` are forwarded. If not, they are dropped.
+This means callers can always pass all parameters safely.
+
+```python
+if issubclass(plugin, AbstractRemoteDB):
+    return plugin(name=name, subfolder=subfolder, password=password, host=host, port=port)
+return plugin(name=name, subfolder=subfolder, password=password)
+```
+
+Source: `hivemind_plugin_manager/__init__.py:33`
+
+---
+
+## Plugin Lifecycle
+
+A plugin class is loaded once when `find_plugins()` is called. Factories instantiate a new
+object per `create()` call. There is no HPM-managed teardown; cleanup is the plugin's
+responsibility (e.g. close database connections in `__del__` or an explicit `close()` method
+if the implementation adds one).
+
+---
+
+## The `Client` Dataclass
+
+`Client` is the core data model — it represents a device or credential authorised to connect
+to a HiveMind node.
+
+```python
+@dataclass
+class Client:
+    client_id: int
+    api_key: str
+    name: str = ""
+    description: str = ""
+    is_admin: bool = False
+    last_seen: float = -1
+    intent_blacklist: List[str] = field(default_factory=list)
+    skill_blacklist: List[str] = field(default_factory=list)
+    message_blacklist: List[str] = field(default_factory=list)
+    allowed_types: List[str] = field(default_factory=list)
+    crypto_key: Optional[str] = None
+    password: Optional[str] = None
+    can_broadcast: bool = True
+    can_escalate: bool = True
+    can_propagate: bool = True
+```
+
+Source: `hivemind_plugin_manager/database.py:35`
+
+Notable rules enforced in `__post_init__` (`database.py:52`):
+
+- `client_id` must be `int` — raises `ValueError` otherwise.
+- `is_admin` must be `bool` — raises `ValueError` otherwise.
+- `allowed_types` is populated with a default set of OVOS message types when empty.
+- `"recognizer_loop:utterance"` is always appended to `allowed_types` even if the caller
+  provides a custom list.
+
+---
+
+## `_SubProtocol` Base
+
+All three protocol base classes (`AgentProtocol`, `NetworkProtocol`,
+`BinaryDataHandlerProtocol`) inherit from `_SubProtocol` (`protocols.py:35`), which
+provides three convenience properties:
+
+| Property | Returns when `hm_protocol` is set | Returns when not set |
+|---|---|---|
+| `identity` | `hm_protocol.identity` (`NodeIdentity`) | fresh `NodeIdentity()` |
+| `database` | `hm_protocol.db` | `None` |
+| `clients` | `hm_protocol.clients` (dict) | `{}` |
+
+Source: `hivemind_plugin_manager/protocols.py:35`
+
+`hm_protocol` is a forward reference to `HiveMindListenerProtocol` (from `hivemind-core`).
+It is `None` during unit tests and during construction when the protocol is passed as a
+constructor argument to `HiveMindListenerProtocol` (which assigns `self` back afterward).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,116 @@
+# Contributing
+
+## Repository
+
+`https://github.com/JarbasHiveMind/hivemind-plugin-manager`
+
+Default branch: `dev`. Pull requests target `dev`, not `master`.
+
+---
+
+## Setup
+
+```bash
+git clone https://github.com/JarbasHiveMind/hivemind-plugin-manager
+cd hivemind-plugin-manager
+git checkout dev
+pip install -e ".[dev]"          # or: pip install -e . && pip install pytest pytest-cov
+```
+
+---
+
+## Running Tests
+
+```bash
+pytest tests/ -v
+```
+
+Tests live in `tests/`:
+
+| File | What it covers |
+|---|---|
+| `tests/test_database.py` | `Client`, `cast2client`, `AbstractDB`, `AbstractRemoteDB` |
+| `tests/test_factories.py` | all four factories, `find_plugins`, `HiveMindPluginTypes` |
+| `tests/test_protocols.py` | `ClientCallbacks`, `AgentProtocol`, `NetworkProtocol`, `BinaryDataHandlerProtocol` |
+
+---
+
+## Coverage Gate
+
+The CI coverage workflow enforces a minimum of **70 % line coverage**. Check before opening
+a PR:
+
+```bash
+pytest tests/ --cov=hivemind_plugin_manager --cov-report=term-missing
+```
+
+---
+
+## CI Workflows
+
+All workflows are in `.github/workflows/`. They use reusable workflows from
+`OpenVoiceOS/gh-automations@dev`.
+
+| Workflow file | Trigger | Purpose |
+|---|---|---|
+| `build_tests.yml` | push / PR | run `pytest` across Python versions |
+| `coverage.yml` | push / PR | measure coverage, fail below threshold |
+| `lint.yml` | push / PR | `flake8` / `pylint` style checks |
+| `license_check.yml` | push / PR | verify all dependencies are permissively licensed |
+| `pip_audit.yml` | push / PR | scan for known vulnerabilities in dependencies |
+| `conventional-label.yaml` | PR open/edit | auto-label PRs by conventional-commit prefix |
+| `repo-health.yml` | schedule | general repository health checks |
+| `release-preview.yml` | push to `dev` | publish an alpha pre-release |
+| `release_workflow.yml` | manual / tag | cut a versioned release |
+| `publish_stable.yml` | release published | publish to PyPI |
+
+---
+
+## Commit Convention
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/).
+
+```
+<type>(<scope>): <short description>
+
+feat(database): add AbstractRemoteDB password rotation helper
+fix(factory): raise KeyError with available plugin list
+docs: add binary protocol guide
+test(protocols): cover BinaryDataHandlerProtocol post_init branch
+```
+
+Common types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `ci`.
+
+The `conventional-label.yaml` workflow auto-labels PRs based on the commit prefix.
+
+---
+
+## Versioning
+
+Version is read from `hivemind_plugin_manager/version.py`:
+
+```python
+VERSION_MAJOR = 0
+VERSION_MINOR = 4
+VERSION_BUILD = 1
+VERSION_ALPHA = 1   # 0 = stable release
+```
+
+Source: `hivemind_plugin_manager/version.py:1`
+
+`setup.py:7` assembles the version string as `{MAJOR}.{MINOR}.{BUILD}` with an `a{ALPHA}`
+suffix when `VERSION_ALPHA > 0`.
+
+Bump the appropriate component in `version.py` before opening a release PR.
+
+---
+
+## Adding a New Plugin Type
+
+If a future HiveMind version requires a fifth plugin type:
+
+1. Add a new member to `HiveMindPluginTypes` in `__init__.py:10`.
+2. Create a new abstract base dataclass in either `database.py` or `protocols.py`.
+3. Add a new factory class following the pattern of `DatabaseFactory` (`__init__.py:17`).
+4. Add tests in a new `tests/test_<type>.py` file.
+5. Update `docs/README.md`, `docs/concepts.md`, and add a new `docs/plugins/<type>.md`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,138 @@
+# Getting Started
+
+## What Is HiveMind Plugin Manager?
+
+HiveMind Plugin Manager (HPM) is the extension layer that lets the HiveMind ecosystem swap its
+storage backend, agent integration, network transport, and binary data handling without changing
+core code. Every implementation — whether a JSON file database, a WebSocket server, or an audio
+handler — is a separate installable Python package that registers itself under a standardised
+setuptools entry-point group. HPM discovers those entry points at runtime and exposes factory
+classes so callers never need to hard-code import paths.
+
+There are exactly four plugin types:
+
+| Type | Entry-point group | What it does |
+|---|---|---|
+| `DATABASE` | `hivemind.database` | Stores and retrieves `Client` credentials |
+| `AGENT_PROTOCOL` | `hivemind.agent.protocol` | Bridges HiveMind messages to an AI backend |
+| `NETWORK_PROTOCOL` | `hivemind.network.protocol` | Transports `HiveMessage` objects over a wire |
+| `BINARY_PROTOCOL` | `hivemind.binary.protocol` | Handles raw binary payloads (audio, images, files) |
+
+Source: `hivemind_plugin_manager/__init__.py:10`
+
+---
+
+## Install
+
+```bash
+pip install hivemind-plugin-manager
+```
+
+Runtime dependencies pulled in automatically: `json_database`, `ovos-bus-client`, `ovos-utils`,
+and `hivemind-bus-client` (via protocols).
+
+---
+
+## Verify Installation
+
+```python
+from hivemind_plugin_manager import find_plugins, HiveMindPluginTypes
+
+# Returns a dict of {plugin_name: class} for every installed DB plugin
+print(find_plugins(HiveMindPluginTypes.DATABASE))
+```
+
+If you have `hivemind-json-db-plugin` installed you will see something like:
+
+```
+{'hivemind-json-db-plugin': <class 'json_database.hpm.JsonDB'>}
+```
+
+---
+
+## Hello-World Plugin (Database)
+
+The fastest way to understand HPM is to write a trivial database plugin and register it.
+
+### 1. Implement the abstract class
+
+```python
+# my_hpm_plugin/db.py
+from typing import List, Iterable, Union
+from hivemind_plugin_manager.database import AbstractDB, Client
+
+
+class InMemoryDB(AbstractDB):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._store: List[Client] = []
+
+    def add_item(self, client: Client) -> bool:
+        for i, c in enumerate(self._store):
+            if c.client_id == client.client_id:
+                self._store[i] = client
+                return True
+        self._store.append(client)
+        return True
+
+    def search_by_value(self, key: str,
+                        val: Union[str, bool, int, float]) -> List[Client]:
+        return [c for c in self._store if getattr(c, key, None) == val]
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+    def __iter__(self) -> Iterable[Client]:
+        return iter(self._store)
+```
+
+### 2. Register the entry point
+
+In `setup.py` (or `pyproject.toml`):
+
+```python
+# setup.py
+setup(
+    name="my-hpm-plugin",
+    ...
+    entry_points={
+        "hivemind.database": [
+            "my-inmemory-db-plugin = my_hpm_plugin.db:InMemoryDB"
+        ]
+    }
+)
+```
+
+### 3. Install and verify
+
+```bash
+pip install -e .
+python -c "from hivemind_plugin_manager import find_plugins, HiveMindPluginTypes; print(find_plugins(HiveMindPluginTypes.DATABASE))"
+# {'my-inmemory-db-plugin': <class 'my_hpm_plugin.db.InMemoryDB'>}
+```
+
+### 4. Instantiate via factory
+
+```python
+from hivemind_plugin_manager import DatabaseFactory
+
+db = DatabaseFactory.create("my-inmemory-db-plugin", name="clients", subfolder="hivemind-core")
+```
+
+`DatabaseFactory.create` — `hivemind_plugin_manager/__init__.py:26`
+
+---
+
+## CLI Tool: `hpm`
+
+After installation a `hpm` command is available (entry point registered in `setup.py:54`):
+
+```bash
+hpm list database          # list installed database plugins
+hpm get database           # show currently configured database plugin
+hpm set database hivemind-json-db-plugin   # activate a plugin
+hpm show-config            # dump full server.json
+```
+
+Config is stored in `~/.config/hivemind-core/server.json` (XDG).
+See `hivemind_plugin_manager/tui.py` for full CLI implementation.

--- a/docs/plugins/agent-protocol.md
+++ b/docs/plugins/agent-protocol.md
@@ -1,0 +1,150 @@
+# Agent Protocol Plugin Guide
+
+An agent protocol plugin bridges HiveMind messages to an AI backend — for example routing
+utterances to an OVOS message bus or to a local persona/LLM. HPM provides the abstract base
+class; every concrete implementation is a separate package.
+
+---
+
+## Base Class
+
+```python
+@dataclass
+class AgentProtocol(_SubProtocol):
+    """protocol to handle Message objects, the payload of HiveMessage objects"""
+    bus: Union[FakeBus, MessageBusClient] = dataclasses.field(default_factory=FakeBus)
+    config: Dict[str, Any] = dataclasses.field(default_factory=dict)
+    hm_protocol: Optional['HiveMindListenerProtocol'] = None
+    callbacks: ClientCallbacks = dataclasses.field(default_factory=ClientCallbacks)
+```
+
+Source: `hivemind_plugin_manager/protocols.py:61`
+
+`AgentProtocol` extends `_SubProtocol` (`protocols.py:35`) which provides `.identity`,
+`.database`, and `.clients` properties (see [Concepts](../concepts.md#_subprotocol-base)).
+
+---
+
+## Constructor Signature
+
+```python
+def __init__(self,
+             config: Dict[str, Any] = None,
+             bus: Union[FakeBus, MessageBusClient] = None,
+             hm_protocol: HiveMindListenerProtocol = None):
+```
+
+`AgentProtocolFactory.create` passes these three kwargs — no others.
+Source: `hivemind_plugin_manager/__init__.py:47`
+
+| Parameter | Purpose |
+|---|---|
+| `config` | Plugin-specific configuration dict (e.g. host/port of the message bus) |
+| `bus` | Pre-existing bus connection; factory passes `None` and lets the plugin create its own |
+| `hm_protocol` | Back-reference to the owning `HiveMindListenerProtocol`; `None` during construction, assigned later |
+
+---
+
+## Minimal Implementation
+
+```python
+# my_package/agent.py
+from dataclasses import dataclass, field
+from typing import Dict, Any, Optional, Union
+
+from ovos_utils.fakebus import FakeBus
+from ovos_bus_client import MessageBusClient
+from hivemind_plugin_manager.protocols import AgentProtocol
+
+
+@dataclass
+class EchoAgentProtocol(AgentProtocol):
+    """Echoes every utterance back as a spoken response (demo only)."""
+
+    def __post_init__(self):
+        # Connect to the bus if not provided
+        if not self.bus or isinstance(self.bus, FakeBus):
+            host = self.config.get("host", "127.0.0.1")
+            port = self.config.get("port", 8181)
+            self.bus = MessageBusClient(host=host, port=port)
+            self.bus.run_in_thread()
+
+    def handle_utterance(self, utterance: str, lang: str = "en-us",
+                         client=None):
+        """Called by HiveMindListenerProtocol for each recognised utterance."""
+        self.bus.emit(
+            Message("speak", {"utterance": f"You said: {utterance}"})
+        )
+```
+
+The exact methods you override depend on what `HiveMindListenerProtocol` calls on the
+agent protocol — refer to `hivemind-core` for the full interface. HPM only defines the
+dataclass fields and the `_SubProtocol` property helpers.
+
+---
+
+## Entry-Point Registration
+
+```python
+entry_points={
+    "hivemind.agent.protocol": [
+        "my-echo-agent-plugin = my_package.agent:EchoAgentProtocol"
+    ]
+}
+```
+
+Group name must be exactly `"hivemind.agent.protocol"` —
+`HiveMindPluginTypes.AGENT_PROTOCOL`. Source: `hivemind_plugin_manager/__init__.py:13`
+
+---
+
+## Factory Usage
+
+```python
+from hivemind_plugin_manager import AgentProtocolFactory
+
+agent = AgentProtocolFactory.create(
+    "my-echo-agent-plugin",
+    config={"host": "127.0.0.1", "port": 8181},
+)
+```
+
+`AgentProtocolFactory.create` — `hivemind_plugin_manager/__init__.py:47`
+
+---
+
+## `ClientCallbacks` Integration
+
+`AgentProtocol` inherits a `callbacks: ClientCallbacks` field (`protocols.py:67`).
+`ClientCallbacks` holds four callables invoked by `HiveMindListenerProtocol` at connection
+lifecycle events:
+
+```python
+@dataclass
+class ClientCallbacks:
+    on_connect:          Callable[['HiveMindClientConnection'], None]
+    on_disconnect:       Callable[['HiveMindClientConnection'], None]
+    on_invalid_key:      Callable[['HiveMindClientConnection'], None]
+    on_invalid_protocol: Callable[['HiveMindClientConnection'], None]
+```
+
+Source: `hivemind_plugin_manager/protocols.py:27`
+
+Override in your plugin's `__post_init__` if you need to react to connections:
+
+```python
+def __post_init__(self):
+    self.callbacks.on_connect = self._on_client_connected
+
+def _on_client_connected(self, client):
+    self.bus.emit(Message("hm.client.connected", {"client_id": client.client_id}))
+```
+
+---
+
+## Known Implementations
+
+| Package | Entry-point name |
+|---|---|
+| `ovos-bus-client` (hpm extra) | `hivemind-ovos-agent-plugin` |
+| `ovos-persona` (hpm extra) | `hivemind-persona-agent-plugin` |

--- a/docs/plugins/binary-protocol.md
+++ b/docs/plugins/binary-protocol.md
@@ -1,0 +1,200 @@
+# Binary Protocol Plugin Guide
+
+A binary data handler protocol plugin processes raw binary `HiveMessage` payloads — audio
+streams, STT requests, camera images, TTS audio, and arbitrary file transfers.
+
+The base class provides **no-op implementations** of every handler so that a subclass only
+needs to override the handlers it actually cares about.
+
+---
+
+## Base Class
+
+```python
+@dataclass
+class BinaryDataHandlerProtocol(_SubProtocol):
+    """protocol to handle Binary data HiveMessage objects"""
+    config: Dict[str, Any] = dataclasses.field(default_factory=dict)
+    hm_protocol: Optional['HiveMindListenerProtocol'] = None
+    agent_protocol: Optional['AgentProtocol'] = None
+    callbacks: ClientCallbacks = dataclasses.field(default_factory=ClientCallbacks)
+```
+
+Source: `hivemind_plugin_manager/protocols.py:88`
+
+---
+
+## `__post_init__` Behaviour
+
+```python
+def __post_init__(self):
+    if not self.agent_protocol and self.hm_protocol:
+        self.agent_protocol = self.hm_protocol.agent_protocol
+```
+
+Source: `hivemind_plugin_manager/protocols.py:96`
+
+If `agent_protocol` is not provided explicitly but `hm_protocol` is available, the binary
+protocol inherits the agent protocol from it. An explicit `agent_protocol` kwarg always
+wins.
+
+---
+
+## Constructor Signature
+
+`BinaryDataHandlerProtocolFactory.create` passes:
+
+```python
+plugin(config=config, hm_protocol=hm_protocol, agent_protocol=agent_protocol)
+```
+
+Source: `hivemind_plugin_manager/__init__.py:88`
+
+---
+
+## Handler Methods
+
+All handlers have no-op defaults that emit a `LOG.warning`. Override the ones you need.
+
+### `handle_microphone_input`
+
+```python
+def handle_microphone_input(self, bin_data: bytes,
+                            sample_rate: int,
+                            sample_width: int,
+                            client: 'HiveMindClientConnection'):
+```
+
+Source: `hivemind_plugin_manager/protocols.py:101`
+
+Raw microphone audio from a satellite device. Typical action: forward to an STT engine.
+
+### `handle_stt_transcribe_request`
+
+```python
+def handle_stt_transcribe_request(self, bin_data: bytes,
+                                  sample_rate: int,
+                                  sample_width: int,
+                                  lang: str,
+                                  client: 'HiveMindClientConnection'):
+```
+
+Source: `hivemind_plugin_manager/protocols.py:107`
+
+Client requests transcription of audio and wants the text back.
+
+### `handle_stt_handle_request`
+
+```python
+def handle_stt_handle_request(self, bin_data: bytes,
+                              sample_rate: int,
+                              sample_width: int,
+                              lang: str,
+                              client: 'HiveMindClientConnection'):
+```
+
+Source: `hivemind_plugin_manager/protocols.py:114`
+
+Client requests transcription **and** intent handling of audio.
+
+### `handle_numpy_image`
+
+```python
+def handle_numpy_image(self, bin_data: bytes,
+                       camera_id: str,
+                       client: 'HiveMindClientConnection'):
+```
+
+Source: `hivemind_plugin_manager/protocols.py:121`
+
+Raw image bytes from a camera peripheral.
+
+### `handle_receive_tts`
+
+```python
+def handle_receive_tts(self, bin_data: bytes,
+                       utterance: str,
+                       lang: str,
+                       file_name: str,
+                       client: 'HiveMindClientConnection'):
+```
+
+Source: `hivemind_plugin_manager/protocols.py:127`
+
+TTS audio synthesised by the node, delivered to the plugin for forwarding or playback.
+
+### `handle_receive_file`
+
+```python
+def handle_receive_file(self, bin_data: bytes,
+                        file_name: str,
+                        client: 'HiveMindClientConnection'):
+```
+
+Source: `hivemind_plugin_manager/protocols.py:133`
+
+Arbitrary file received from a client.
+
+---
+
+## Minimal Implementation
+
+```python
+# my_package/binary.py
+import io
+import wave
+from dataclasses import dataclass
+from hivemind_plugin_manager.protocols import BinaryDataHandlerProtocol
+
+
+@dataclass
+class WavFileBinaryProtocol(BinaryDataHandlerProtocol):
+    """Saves every microphone input chunk to a .wav file."""
+
+    def handle_microphone_input(self, bin_data, sample_rate, sample_width, client):
+        path = f"/tmp/hm_audio_{client.client_id}.wav"
+        with wave.open(path, "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(sample_width)
+            wf.setframerate(sample_rate)
+            wf.writeframes(bin_data)
+```
+
+---
+
+## Entry-Point Registration
+
+```python
+entry_points={
+    "hivemind.binary.protocol": [
+        "my-wav-binary-plugin = my_package.binary:WavFileBinaryProtocol"
+    ]
+}
+```
+
+Group name must be exactly `"hivemind.binary.protocol"` —
+`HiveMindPluginTypes.BINARY_PROTOCOL`. Source: `hivemind_plugin_manager/__init__.py:14`
+
+---
+
+## Factory Usage
+
+```python
+from hivemind_plugin_manager import BinaryDataHandlerProtocolFactory
+
+handler = BinaryDataHandlerProtocolFactory.create(
+    "my-wav-binary-plugin",
+    config={},
+    agent_protocol=my_agent,
+)
+```
+
+`BinaryDataHandlerProtocolFactory.create` — `hivemind_plugin_manager/__init__.py:83`
+
+---
+
+## Known Implementations
+
+| Package | Entry-point name |
+|---|---|
+| `hivemind-listener` | `hivemind-audio-binary-protocol-plugin` |

--- a/docs/plugins/database.md
+++ b/docs/plugins/database.md
@@ -1,0 +1,237 @@
+# Database Plugin Guide
+
+Database plugins store and retrieve `Client` records — the credentials/permissions of every
+device that connects to a HiveMind node. HPM ships no database implementation itself; it
+defines the abstract contract that every implementation must satisfy.
+
+---
+
+## Choose Your Base Class
+
+| Base class | Use when |
+|---|---|
+| `AbstractDB` | Storage is local (file, SQLite, in-memory) |
+| `AbstractRemoteDB` | Storage requires a network connection (Redis, REST API, etc.) |
+
+`AbstractRemoteDB` extends `AbstractDB` with `host` and `port` dataclass fields and
+re-declares the same abstract methods so IDEs show the correct signature.
+
+Sources:
+- `AbstractDB` — `hivemind_plugin_manager/database.py:158`
+- `AbstractRemoteDB` — `hivemind_plugin_manager/database.py:266`
+
+---
+
+## AbstractDB Contract
+
+### Required (abstract) methods
+
+```python
+def add_item(self, client: Client) -> bool: ...
+def search_by_value(self, key: str,
+                    val: Union[str, bool, int, float]) -> List[Client]: ...
+def __len__(self) -> int: ...
+def __iter__(self) -> Iterable[Client]: ...
+```
+
+### Provided (concrete) methods — override only if needed
+
+| Method | Default behaviour | Source |
+|---|---|---|
+| `delete_item(client)` | Replaces entry with `Client(client_id=..., api_key="revoked")` — **does not remove the row** | `database.py:181` |
+| `update_item(client)` | Delegates to `add_item(client)` | `database.py:195` |
+| `replace_item(old, new)` | Calls `delete_item(old)` then `add_item(new)` | `database.py:207` |
+| `sync()` | No-op; override to reload from disk | `database.py:252` |
+| `commit()` | Returns `True`; override to flush writes | `database.py:256` |
+
+### Dataclass fields
+
+```python
+@dataclass
+class AbstractDB(abc.ABC):
+    name: str = "clients"
+    subfolder: str = "hivemind-core"
+    password: Optional[str] = None
+```
+
+`name` and `subfolder` map to XDG data paths in file-backed implementations.
+
+---
+
+## AbstractRemoteDB Contract
+
+Same abstract methods as `AbstractDB`, plus:
+
+```python
+@dataclass
+class AbstractRemoteDB(AbstractDB):
+    host: str = "127.0.0.1"
+    port: Optional[int] = None
+    name: str = "clients"
+    subfolder: str = "hivemind-core"
+    password: Optional[str] = None
+```
+
+Source: `hivemind_plugin_manager/database.py:267`
+
+`DatabaseFactory.create` detects `issubclass(plugin, AbstractRemoteDB)` and passes `host`
+and `port` to the constructor. Source: `hivemind_plugin_manager/__init__.py:33`
+
+---
+
+## Concrete Walkthrough — Local Plugin
+
+```python
+# my_package/db.py
+from dataclasses import dataclass, field
+from typing import List, Iterable, Union
+from hivemind_plugin_manager.database import AbstractDB, Client
+
+
+@dataclass
+class JsonFileDB(AbstractDB):
+    """Minimal JSON-file-backed database."""
+    # AbstractDB already provides: name, subfolder, password
+    # Add your own fields here if needed.
+
+    def __post_init__(self):
+        import json, os
+        from ovos_utils.xdg_utils import xdg_data_home
+        self._path = os.path.join(
+            xdg_data_home(), self.subfolder, f"{self.name}.json"
+        )
+        os.makedirs(os.path.dirname(self._path), exist_ok=True)
+        try:
+            with open(self._path) as f:
+                raw = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            raw = []
+        self._data: List[Client] = [Client.deserialize(r) for r in raw]
+
+    # --- required ---
+
+    def add_item(self, client: Client) -> bool:
+        for i, c in enumerate(self._data):
+            if c.client_id == client.client_id:
+                self._data[i] = client
+                return self.commit()
+        self._data.append(client)
+        return self.commit()
+
+    def search_by_value(self, key: str,
+                        val: Union[str, bool, int, float]) -> List[Client]:
+        return [c for c in self._data if getattr(c, key, None) == val]
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __iter__(self) -> Iterable[Client]:
+        return iter(self._data)
+
+    # --- optional overrides ---
+
+    def commit(self) -> bool:
+        import json
+        with open(self._path, "w") as f:
+            json.dump([c.__dict__ for c in self._data], f, indent=2)
+        return True
+
+    def sync(self):
+        self.__post_init__()
+```
+
+---
+
+## Concrete Walkthrough — Remote Plugin
+
+```python
+# my_package/remote_db.py
+import redis
+from dataclasses import dataclass
+from typing import List, Iterable, Union
+from hivemind_plugin_manager.database import AbstractRemoteDB, Client
+
+
+@dataclass
+class RedisDB(AbstractRemoteDB):
+    # AbstractRemoteDB provides: host, port, name, subfolder, password
+
+    def __post_init__(self):
+        self._r = redis.Redis(
+            host=self.host,
+            port=self.port or 6379,
+            password=self.password,
+            decode_responses=True,
+        )
+
+    def add_item(self, client: Client) -> bool:
+        self._r.hset(self.name, client.client_id, client.serialize())
+        return True
+
+    def search_by_value(self, key: str,
+                        val: Union[str, bool, int, float]) -> List[Client]:
+        return [c for c in self if getattr(c, key, None) == val]
+
+    def __len__(self) -> int:
+        return self._r.hlen(self.name)
+
+    def __iter__(self) -> Iterable[Client]:
+        for raw in self._r.hvals(self.name):
+            yield Client.deserialize(raw)
+```
+
+---
+
+## Entry-Point Registration
+
+```python
+# setup.py
+entry_points={
+    "hivemind.database": [
+        "my-json-db-plugin = my_package.db:JsonFileDB",
+        "my-redis-db-plugin = my_package.remote_db:RedisDB",
+    ]
+}
+```
+
+The entry-point group must be exactly `"hivemind.database"` — the value of
+`HiveMindPluginTypes.DATABASE`. Source: `hivemind_plugin_manager/__init__.py:11`
+
+---
+
+## The `delete_item` Tombstone Pattern
+
+`AbstractDB.delete_item` does **not** remove the row. It replaces the entry with a
+tombstone:
+
+```python
+client = Client(client_id=client.client_id, api_key="revoked")
+return self.update_item(client)
+```
+
+Source: `hivemind_plugin_manager/database.py:192`
+
+This prevents `client_id` reuse. If your storage backend requires a true delete (e.g. you
+have a unique constraint on `api_key`), override `delete_item` and implement the tombstone
+yourself, or skip the tombstone and rely on your own ID-sequencing strategy.
+
+---
+
+## The `Client` Object
+
+See [Concepts — The Client Dataclass](../concepts.md#the-client-dataclass) for the full
+field listing. Useful helpers:
+
+- `Client.serialize()` → JSON string — `database.py:71`
+- `Client.deserialize(str | dict)` → `Client` — `database.py:81`
+- `cast2client(value)` — converts `str`, `dict`, or `list` to `Client` / `List[Client]` — `database.py:15`
+
+---
+
+## Known Implementations
+
+| Package | Entry-point name | Type |
+|---|---|---|
+| `hivemind-json-db-plugin` | `hivemind-json-db-plugin` | Local (`AbstractDB`) |
+| `hivemind-sqlite-db-plugin` | `hivemind-sqlite-db-plugin` | Local (`AbstractDB`) |
+| `hivemind-redis-db-plugin` | `hivemind-redis-db-plugin` | Remote (`AbstractRemoteDB`) |

--- a/docs/plugins/network-protocol.md
+++ b/docs/plugins/network-protocol.md
@@ -1,0 +1,128 @@
+# Network Protocol Plugin Guide
+
+A network protocol plugin is responsible for transporting `HiveMessage` objects between a
+HiveMind node and its clients — for example over WebSockets, ZeroMQ, or a serial link.
+It is the only plugin type that has an **abstract method** defined directly on the base class.
+
+---
+
+## Base Class
+
+```python
+@dataclass
+class NetworkProtocol(_SubProtocol):
+    """protocol to transport HiveMessage objects around"""
+    config: Dict[str, Any] = dataclasses.field(default_factory=dict)
+    hm_protocol: Optional['HiveMindListenerProtocol'] = None
+    callbacks: ClientCallbacks = dataclasses.field(default_factory=ClientCallbacks)
+
+    @property
+    def agent_protocol(self) -> Optional['AgentProtocol']:
+        if not self.hm_protocol:
+            return None
+        return self.hm_protocol.agent_protocol
+
+    @abc.abstractmethod
+    def run(self):
+        pass
+```
+
+Source: `hivemind_plugin_manager/protocols.py:70`
+
+`NetworkProtocol` extends `_SubProtocol`, so `.identity`, `.database`, and `.clients` are
+available via `hm_protocol`. It additionally exposes `.agent_protocol` as a shortcut to
+`hm_protocol.agent_protocol`.
+
+---
+
+## The `run()` Method
+
+`run()` is the single abstract method. It must block and serve connections. The caller
+(typically `hivemind-core`) calls `run()` in a thread or process. When `run()` returns, the
+server is considered stopped.
+
+---
+
+## Constructor Signature
+
+`NetworkProtocolFactory.create` passes:
+
+```python
+plugin(config=config, hm_protocol=hm_protocol)
+```
+
+Source: `hivemind_plugin_manager/__init__.py:69`
+
+| Parameter | Purpose |
+|---|---|
+| `config` | Dict with transport settings (host, port, SSL, etc.) |
+| `hm_protocol` | Back-reference to the owning `HiveMindListenerProtocol` |
+
+---
+
+## Minimal Implementation
+
+```python
+# my_package/network.py
+import socket
+from dataclasses import dataclass
+from hivemind_plugin_manager.protocols import NetworkProtocol
+
+
+@dataclass
+class TcpNetworkProtocol(NetworkProtocol):
+    """Bare TCP server — for illustration only."""
+
+    def run(self):
+        host = self.config.get("host", "0.0.0.0")
+        port = self.config.get("port", 5678)
+        with socket.socket() as srv:
+            srv.bind((host, port))
+            srv.listen(5)
+            while True:
+                conn, addr = srv.accept()
+                self._handle(conn, addr)
+
+    def _handle(self, conn, addr):
+        # read HiveMessage bytes, route via self.hm_protocol, send response
+        pass
+```
+
+---
+
+## Entry-Point Registration
+
+```python
+entry_points={
+    "hivemind.network.protocol": [
+        "my-tcp-plugin = my_package.network:TcpNetworkProtocol"
+    ]
+}
+```
+
+Group name must be exactly `"hivemind.network.protocol"` —
+`HiveMindPluginTypes.NETWORK_PROTOCOL`. Source: `hivemind_plugin_manager/__init__.py:12`
+
+---
+
+## Factory Usage
+
+```python
+from hivemind_plugin_manager import NetworkProtocolFactory
+
+server = NetworkProtocolFactory.create(
+    "my-tcp-plugin",
+    config={"host": "0.0.0.0", "port": 5678},
+)
+server.run()   # blocks
+```
+
+`NetworkProtocolFactory.create` — `hivemind_plugin_manager/__init__.py:64`
+
+---
+
+## Known Implementations
+
+| Package | Entry-point name |
+|---|---|
+| `hivemind-websocket-protocol` | `hivemind-websocket-plugin` |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+hivemind_bus_client
 json_database
 ovos-bus-client
 ovos-utils

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,245 @@
+import json
+import unittest
+from typing import List, Union, Iterable
+
+from hivemind_plugin_manager.database import (
+    AbstractDB,
+    AbstractRemoteDB,
+    Client,
+    cast2client,
+)
+
+
+class _InMemoryDB(AbstractDB):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._items: List[Client] = []
+
+    def add_item(self, client: Client) -> bool:
+        for i, c in enumerate(self._items):
+            if c.client_id == client.client_id:
+                self._items[i] = client
+                return True
+        self._items.append(client)
+        return True
+
+    def search_by_value(self, key: str, val) -> List[Client]:
+        return [c for c in self._items if getattr(c, key, None) == val]
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __iter__(self) -> Iterable[Client]:
+        return iter(self._items)
+
+
+class _InMemoryRemoteDB(AbstractRemoteDB):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._items: List[Client] = []
+
+    def add_item(self, client: Client) -> bool:
+        self._items.append(client)
+        return True
+
+    def search_by_value(self, key: str, val) -> List[Client]:
+        return [c for c in self._items if getattr(c, key, None) == val]
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __iter__(self) -> Iterable[Client]:
+        return iter(self._items)
+
+
+class TestClient(unittest.TestCase):
+    def _make(self, **overrides) -> Client:
+        defaults = dict(client_id=1, api_key="k", name="alice")
+        defaults.update(overrides)
+        return Client(**defaults)
+
+    def test_defaults_populate_allowed_types(self):
+        c = self._make()
+        self.assertIn("recognizer_loop:utterance", c.allowed_types)
+        self.assertGreater(len(c.allowed_types), 1)
+
+    def test_allowed_types_always_contains_utterance(self):
+        c = self._make(allowed_types=["custom:event"])
+        self.assertIn("recognizer_loop:utterance", c.allowed_types)
+        self.assertIn("custom:event", c.allowed_types)
+
+    def test_post_init_rejects_non_int_client_id(self):
+        with self.assertRaises(ValueError):
+            Client(client_id="1", api_key="k")
+
+    def test_post_init_rejects_non_bool_is_admin(self):
+        with self.assertRaises(ValueError):
+            Client(client_id=1, api_key="k", is_admin="yes")
+
+    def test_serialize_returns_json_string(self):
+        c = self._make()
+        data = json.loads(c.serialize())
+        self.assertEqual(data["client_id"], 1)
+        self.assertEqual(data["api_key"], "k")
+        self.assertEqual(data["name"], "alice")
+
+    def test_deserialize_from_dict(self):
+        c = Client.deserialize({"client_id": 2, "api_key": "z", "name": "bob"})
+        self.assertEqual(c.client_id, 2)
+        self.assertEqual(c.name, "bob")
+
+    def test_deserialize_from_json_string(self):
+        payload = json.dumps({"client_id": 3, "api_key": "y", "name": "eve"})
+        c = Client.deserialize(payload)
+        self.assertEqual(c.client_id, 3)
+
+    def test_getitem_returns_attribute(self):
+        c = self._make()
+        self.assertEqual(c["name"], "alice")
+
+    def test_getitem_raises_on_unknown(self):
+        c = self._make()
+        with self.assertRaises(KeyError):
+            _ = c["does_not_exist"]
+
+    def test_setitem_updates_attribute(self):
+        c = self._make()
+        c["name"] = "renamed"
+        self.assertEqual(c.name, "renamed")
+
+    def test_setitem_raises_on_unknown(self):
+        c = self._make()
+        with self.assertRaises(ValueError):
+            c["does_not_exist"] = 1
+
+    def test_equality_same_data(self):
+        a = self._make()
+        b = self._make()
+        self.assertEqual(a, b)
+
+    def test_equality_against_dict(self):
+        a = self._make()
+        self.assertEqual(a, json.loads(a.serialize()))
+
+    def test_equality_against_json_string(self):
+        a = self._make()
+        self.assertEqual(a, a.serialize())
+
+    def test_inequality_against_unrelated_type(self):
+        a = self._make()
+        self.assertNotEqual(a, 42)
+
+    def test_repr_is_serialized(self):
+        c = self._make()
+        self.assertEqual(repr(c), c.serialize())
+
+
+class TestCast2Client(unittest.TestCase):
+    def test_none_passthrough(self):
+        self.assertIsNone(cast2client(None))
+
+    def test_client_passthrough(self):
+        c = Client(client_id=1, api_key="k")
+        self.assertIs(cast2client(c), c)
+
+    def test_from_dict(self):
+        c = cast2client({"client_id": 1, "api_key": "k"})
+        self.assertIsInstance(c, Client)
+
+    def test_from_json_string(self):
+        c = cast2client(json.dumps({"client_id": 1, "api_key": "k"}))
+        self.assertIsInstance(c, Client)
+
+    def test_from_list(self):
+        result = cast2client(
+            [
+                {"client_id": 1, "api_key": "k"},
+                Client(client_id=2, api_key="k2"),
+            ]
+        )
+        self.assertEqual(len(result), 2)
+        self.assertTrue(all(isinstance(c, Client) for c in result))
+
+    def test_unsupported_type_raises(self):
+        with self.assertRaises(TypeError):
+            cast2client(42)
+
+
+class TestAbstractDB(unittest.TestCase):
+    def test_add_and_iter(self):
+        db = _InMemoryDB()
+        db.add_item(Client(client_id=1, api_key="k", name="a"))
+        db.add_item(Client(client_id=2, api_key="k2", name="b"))
+        self.assertEqual(len(db), 2)
+        names = sorted(c.name for c in db)
+        self.assertEqual(names, ["a", "b"])
+
+    def test_search_by_value(self):
+        db = _InMemoryDB()
+        db.add_item(Client(client_id=1, api_key="k", name="match"))
+        db.add_item(Client(client_id=2, api_key="k2", name="other"))
+        found = db.search_by_value("name", "match")
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].client_id, 1)
+
+    def test_delete_replaces_with_revoked(self):
+        db = _InMemoryDB()
+        db.add_item(Client(client_id=1, api_key="real", name="a"))
+        db.delete_item(Client(client_id=1, api_key="real"))
+        self.assertEqual(len(db), 1)
+        revoked = list(db)[0]
+        self.assertEqual(revoked.api_key, "revoked")
+
+    def test_update_item_delegates_to_add(self):
+        db = _InMemoryDB()
+        c = Client(client_id=1, api_key="k", name="a")
+        db.add_item(c)
+        c2 = Client(client_id=1, api_key="k", name="renamed")
+        db.update_item(c2)
+        self.assertEqual(list(db)[0].name, "renamed")
+
+    def test_replace_item(self):
+        db = _InMemoryDB()
+        old = Client(client_id=1, api_key="old")
+        new = Client(client_id=2, api_key="new")
+        db.add_item(old)
+        db.replace_item(old, new)
+        ids = sorted(c.client_id for c in db)
+        # delete leaves revoked entry, plus new
+        self.assertIn(2, ids)
+
+    def test_commit_default_returns_true(self):
+        db = _InMemoryDB()
+        self.assertTrue(db.commit())
+
+    def test_sync_default_noop(self):
+        db = _InMemoryDB()
+        self.assertIsNone(db.sync())
+
+    def test_default_fields(self):
+        db = _InMemoryDB()
+        self.assertEqual(db.name, "clients")
+        self.assertEqual(db.subfolder, "hivemind-core")
+        self.assertIsNone(db.password)
+
+
+class TestAbstractRemoteDB(unittest.TestCase):
+    def test_default_host_port(self):
+        db = _InMemoryRemoteDB()
+        self.assertEqual(db.host, "127.0.0.1")
+        self.assertIsNone(db.port)
+
+    def test_custom_host_port(self):
+        db = _InMemoryRemoteDB(host="10.0.0.1", port=6379)
+        self.assertEqual(db.host, "10.0.0.1")
+        self.assertEqual(db.port, 6379)
+
+    def test_add_and_search(self):
+        db = _InMemoryRemoteDB()
+        db.add_item(Client(client_id=1, api_key="k", name="x"))
+        self.assertEqual(len(db), 1)
+        self.assertEqual(db.search_by_value("name", "x")[0].client_id, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -1,0 +1,185 @@
+import unittest
+from unittest.mock import patch
+
+from hivemind_plugin_manager import (
+    AgentProtocolFactory,
+    BinaryDataHandlerProtocolFactory,
+    DatabaseFactory,
+    HiveMindPluginTypes,
+    NetworkProtocolFactory,
+    find_plugins,
+)
+from hivemind_plugin_manager.database import AbstractDB, AbstractRemoteDB, Client
+
+
+class _FakeLocalDB(AbstractDB):
+    def add_item(self, client): return True
+    def search_by_value(self, key, val): return []
+    def __len__(self): return 0
+    def __iter__(self): return iter([])
+
+
+class _FakeRemoteDB(AbstractRemoteDB):
+    def add_item(self, client): return True
+    def search_by_value(self, key, val): return []
+    def __len__(self): return 0
+    def __iter__(self): return iter([])
+
+
+class _FakeAgentProtocol:
+    def __init__(self, config=None, bus=None, hm_protocol=None):
+        self.config = config
+        self.bus = bus
+        self.hm_protocol = hm_protocol
+
+
+class _FakeNetworkProtocol:
+    def __init__(self, config=None, hm_protocol=None):
+        self.config = config
+        self.hm_protocol = hm_protocol
+
+
+class _FakeBinaryProtocol:
+    def __init__(self, config=None, hm_protocol=None, agent_protocol=None):
+        self.config = config
+        self.hm_protocol = hm_protocol
+        self.agent_protocol = agent_protocol
+
+
+class TestHiveMindPluginTypes(unittest.TestCase):
+    def test_enum_values(self):
+        self.assertEqual(HiveMindPluginTypes.DATABASE.value, "hivemind.database")
+        self.assertEqual(HiveMindPluginTypes.AGENT_PROTOCOL.value, "hivemind.agent.protocol")
+        self.assertEqual(HiveMindPluginTypes.NETWORK_PROTOCOL.value, "hivemind.network.protocol")
+        self.assertEqual(HiveMindPluginTypes.BINARY_PROTOCOL.value, "hivemind.binary.protocol")
+
+
+class TestDatabaseFactory(unittest.TestCase):
+    @patch("hivemind_plugin_manager.find_plugins")
+    def test_get_class_returns_registered(self, mock_find):
+        mock_find.return_value = {"local": _FakeLocalDB}
+        self.assertIs(DatabaseFactory.get_class("local"), _FakeLocalDB)
+
+    @patch("hivemind_plugin_manager.find_plugins")
+    def test_get_class_raises_on_missing(self, mock_find):
+        mock_find.return_value = {}
+        with self.assertRaises(KeyError):
+            DatabaseFactory.get_class("missing")
+
+    @patch("hivemind_plugin_manager.find_plugins")
+    def test_create_local_db(self, mock_find):
+        mock_find.return_value = {"local": _FakeLocalDB}
+        db = DatabaseFactory.create("local", name="db", subfolder="sf")
+        self.assertIsInstance(db, _FakeLocalDB)
+        self.assertEqual(db.name, "db")
+        self.assertEqual(db.subfolder, "sf")
+
+    @patch("hivemind_plugin_manager.find_plugins")
+    def test_create_remote_db_passes_host_port(self, mock_find):
+        mock_find.return_value = {"remote": _FakeRemoteDB}
+        db = DatabaseFactory.create("remote", host="1.2.3.4", port=9999)
+        self.assertIsInstance(db, _FakeRemoteDB)
+        self.assertEqual(db.host, "1.2.3.4")
+        self.assertEqual(db.port, 9999)
+
+
+class TestAgentProtocolFactory(unittest.TestCase):
+    @patch("hivemind_plugin_manager.find_plugins")
+    def test_get_class(self, mock_find):
+        mock_find.return_value = {"agent": _FakeAgentProtocol}
+        self.assertIs(AgentProtocolFactory.get_class("agent"), _FakeAgentProtocol)
+
+    @patch("hivemind_plugin_manager.find_plugins")
+    def test_get_class_missing(self, mock_find):
+        mock_find.return_value = {}
+        with self.assertRaises(KeyError):
+            AgentProtocolFactory.get_class("agent")
+
+    @patch("hivemind_plugin_manager.find_plugins")
+    def test_create_defaults_empty_config(self, mock_find):
+        mock_find.return_value = {"agent": _FakeAgentProtocol}
+        inst = AgentProtocolFactory.create("agent")
+        self.assertEqual(inst.config, {})
+
+
+class TestNetworkProtocolFactory(unittest.TestCase):
+    @patch("hivemind_plugin_manager.find_plugins")
+    def test_get_class(self, mock_find):
+        mock_find.return_value = {"net": _FakeNetworkProtocol}
+        self.assertIs(NetworkProtocolFactory.get_class("net"), _FakeNetworkProtocol)
+
+    @patch("hivemind_plugin_manager.find_plugins")
+    def test_get_class_missing(self, mock_find):
+        mock_find.return_value = {}
+        with self.assertRaises(KeyError):
+            NetworkProtocolFactory.get_class("net")
+
+    @patch("hivemind_plugin_manager.find_plugins")
+    def test_create_with_config(self, mock_find):
+        mock_find.return_value = {"net": _FakeNetworkProtocol}
+        inst = NetworkProtocolFactory.create("net", config={"a": 1})
+        self.assertEqual(inst.config, {"a": 1})
+
+
+class TestBinaryDataHandlerProtocolFactory(unittest.TestCase):
+    @patch("hivemind_plugin_manager.find_plugins")
+    def test_get_class(self, mock_find):
+        mock_find.return_value = {"bin": _FakeBinaryProtocol}
+        self.assertIs(
+            BinaryDataHandlerProtocolFactory.get_class("bin"), _FakeBinaryProtocol
+        )
+
+    @patch("hivemind_plugin_manager.find_plugins")
+    def test_get_class_missing(self, mock_find):
+        mock_find.return_value = {}
+        with self.assertRaises(KeyError):
+            BinaryDataHandlerProtocolFactory.get_class("bin")
+
+    @patch("hivemind_plugin_manager.find_plugins")
+    def test_create_defaults_empty_config(self, mock_find):
+        mock_find.return_value = {"bin": _FakeBinaryProtocol}
+        inst = BinaryDataHandlerProtocolFactory.create("bin")
+        self.assertEqual(inst.config, {})
+
+
+class TestFindPlugins(unittest.TestCase):
+    @patch("hivemind_plugin_manager._iter_entrypoints")
+    def test_find_plugins_specific_type(self, mock_iter):
+        class _EP:
+            name = "fake"
+            def load(self):
+                return _FakeLocalDB
+        mock_iter.return_value = iter([_EP()])
+        result = find_plugins(HiveMindPluginTypes.DATABASE)
+        self.assertIn("fake", result)
+        self.assertIs(result["fake"], _FakeLocalDB)
+
+    @patch("hivemind_plugin_manager._iter_entrypoints")
+    def test_find_plugins_string_type(self, mock_iter):
+        mock_iter.return_value = iter([])
+        result = find_plugins("hivemind.database")
+        self.assertEqual(result, {})
+
+    @patch("hivemind_plugin_manager._iter_entrypoints")
+    def test_find_plugins_no_type_iterates_all(self, mock_iter):
+        mock_iter.return_value = iter([])
+        result = find_plugins()
+        self.assertEqual(result, {})
+        # called once per HiveMindPluginTypes member
+        self.assertEqual(mock_iter.call_count, len(HiveMindPluginTypes))
+
+    @patch("hivemind_plugin_manager._iter_entrypoints")
+    def test_find_plugins_swallows_load_errors(self, mock_iter):
+        find_plugins._errored = []  # reset
+
+        class _BadEP:
+            name = "bad"
+            def load(self):
+                raise RuntimeError("boom")
+        mock_iter.return_value = iter([_BadEP()])
+        result = find_plugins(HiveMindPluginTypes.DATABASE)
+        self.assertEqual(result, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -1,0 +1,121 @@
+import unittest
+from unittest.mock import MagicMock
+
+from hivemind_plugin_manager.protocols import (
+    AgentProtocol,
+    BinaryDataHandlerProtocol,
+    ClientCallbacks,
+    NetworkProtocol,
+    on_connect,
+    on_disconnect,
+    on_invalid_key,
+    on_invalid_protocol,
+)
+
+
+class TestModuleLevelCallbacks(unittest.TestCase):
+    def test_callbacks_are_callable_and_return_none(self):
+        # Each just logs and returns None; calling with a sentinel must not raise.
+        sentinel = object()
+        self.assertIsNone(on_connect(sentinel))
+        self.assertIsNone(on_disconnect(sentinel))
+        self.assertIsNone(on_invalid_key(sentinel))
+        self.assertIsNone(on_invalid_protocol(sentinel))
+
+
+class TestClientCallbacks(unittest.TestCase):
+    def test_defaults_bound_to_module_functions(self):
+        cb = ClientCallbacks()
+        self.assertIs(cb.on_connect, on_connect)
+        self.assertIs(cb.on_disconnect, on_disconnect)
+        self.assertIs(cb.on_invalid_key, on_invalid_key)
+        self.assertIs(cb.on_invalid_protocol, on_invalid_protocol)
+
+    def test_custom_callbacks_assigned(self):
+        f = lambda c: None  # noqa: E731
+        cb = ClientCallbacks(on_connect=f)
+        self.assertIs(cb.on_connect, f)
+
+
+class TestAgentProtocol(unittest.TestCase):
+    def test_defaults(self):
+        p = AgentProtocol()
+        self.assertEqual(p.config, {})
+        self.assertIsNone(p.hm_protocol)
+        self.assertIsInstance(p.callbacks, ClientCallbacks)
+
+    def test_identity_returns_new_when_no_hm_protocol(self):
+        p = AgentProtocol()
+        # NodeIdentity instantiable; just ensure property doesn't blow up
+        self.assertIsNotNone(p.identity)
+
+    def test_identity_delegates_to_hm_protocol(self):
+        sentinel = object()
+        hm = MagicMock(identity=sentinel)
+        p = AgentProtocol(hm_protocol=hm)
+        self.assertIs(p.identity, sentinel)
+
+    def test_database_none_when_no_hm_protocol(self):
+        self.assertIsNone(AgentProtocol().database)
+
+    def test_database_delegates_to_hm_protocol(self):
+        sentinel = object()
+        hm = MagicMock(db=sentinel)
+        self.assertIs(AgentProtocol(hm_protocol=hm).database, sentinel)
+
+    def test_clients_empty_when_no_hm_protocol(self):
+        self.assertEqual(AgentProtocol().clients, {})
+
+    def test_clients_delegates_to_hm_protocol(self):
+        hm = MagicMock(clients={"a": 1})
+        self.assertEqual(AgentProtocol(hm_protocol=hm).clients, {"a": 1})
+
+
+class TestNetworkProtocol(unittest.TestCase):
+    def test_agent_protocol_none_when_no_hm_protocol(self):
+        # NetworkProtocol is abstract; use a concrete subclass.
+        class _N(NetworkProtocol):
+            def run(self): pass
+        self.assertIsNone(_N().agent_protocol)
+
+    def test_agent_protocol_delegates(self):
+        class _N(NetworkProtocol):
+            def run(self): pass
+        sentinel = object()
+        hm = MagicMock(agent_protocol=sentinel)
+        self.assertIs(_N(hm_protocol=hm).agent_protocol, sentinel)
+
+
+class TestBinaryDataHandlerProtocol(unittest.TestCase):
+    def test_defaults(self):
+        p = BinaryDataHandlerProtocol()
+        self.assertEqual(p.config, {})
+        self.assertIsNone(p.agent_protocol)
+
+    def test_post_init_inherits_agent_protocol_from_hm(self):
+        agent = object()
+        hm = MagicMock(agent_protocol=agent)
+        p = BinaryDataHandlerProtocol(hm_protocol=hm)
+        self.assertIs(p.agent_protocol, agent)
+
+    def test_post_init_does_not_overwrite_explicit_agent(self):
+        explicit = object()
+        other = object()
+        hm = MagicMock(agent_protocol=other)
+        p = BinaryDataHandlerProtocol(hm_protocol=hm, agent_protocol=explicit)
+        self.assertIs(p.agent_protocol, explicit)
+
+    def test_default_handlers_are_noops(self):
+        p = BinaryDataHandlerProtocol()
+        client = object()
+        # Each handler just logs; calling must not raise.
+        p.handle_microphone_input(b"x", 16000, 2, client)
+        p.handle_stt_transcribe_request(b"x", 16000, 2, "en", client)
+        p.handle_stt_handle_request(b"x", 16000, 2, "en", client)
+        p.handle_numpy_image(b"x", "cam0", client)
+        p.handle_receive_tts(b"x", "hi", "en", "out.wav", client)
+        p.handle_receive_file(b"x", "out.bin", client)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Standardizes CI/CD on the shared `OpenVoiceOS/gh-automations` reusable workflows (pinned at `@dev`).

## Migrated
- **build_tests.yml** — was hand-rolled (py3.8, `setup.py bdist_wheel`, no pytest, push-triggered). Now calls `build-tests@dev` with py3.10–3.14 matrix, runs pytest on `tests/`, triggers on PRs to `dev`/`master`.
- **release_workflow.yml** — was `TigreGotico/gh-automations@master` plus three hand-rolled jobs (notify, PyPI publish, curl-based release PR). Collapsed into one `publish-alpha@dev` call with explicit `PYPI_TOKEN` / `MATRIX_TOKEN` secrets and `propose_release: true`.
- **publish_stable.yml** — was `TigreGotico/gh-automations@master` plus hand-rolled jobs. Replaced with `publish-stable@dev`, explicit secrets, built-in `sync_dev: true`.

## Added
- **coverage.yml** — coverage on `hivemind_plugin_manager`, `min_coverage: 0` for now (tests dir is sparse)
- **lint.yml** — ruff, informational
- **release-preview.yml** — predicts next version bump from PR labels
- **repo-health.yml** — README/LICENSE/version.py checks
- **license_check.yml** — blocks GPL/AGPL deps
- **pip_audit.yml** — CVE scan

## Left alone
- **conventional-label.yaml** — already matches the shared template.

## Action required before merging
Ensure these are set as repo or org secrets:
- \`PYPI_TOKEN\`
- \`MATRIX_TOKEN\`

(\`secrets: inherit\` deliberately not used.)