### PR TITLE
feat: policy plugin primitives (PolicyPlugin / Verdict / Mutation)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ for instantiation.
 | Write an agent protocol plugin | [Agent Protocol Plugin Guide](plugins/agent-protocol.md) |
 | Write a network protocol plugin | [Network Protocol Plugin Guide](plugins/network-protocol.md) |
 | Write a binary data handler plugin | [Binary Protocol Plugin Guide](plugins/binary-protocol.md) |
+| Write a policy plugin (admission control) | [Policy Plugin Guide](plugins/policy.md) |
 | Look up every public class and function | [API Reference](api-reference.md) |
 | Understand internals, error handling, identity, factory routing | [Advanced](advanced.md) |
 | Contribute to this package | [Contributing](contributing.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # HiveMind Plugin Manager — Documentation
 
 HiveMind Plugin Manager (HPM) is the extension point system for the HiveMind ecosystem.
-It defines four plugin types (database, agent protocol, network protocol, binary protocol),
+It defines five plugin types (database, agent protocol, network protocol, binary protocol, policy),
 discovers implementations registered via setuptools entry points, and provides factory classes
 for instantiation.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,16 +28,20 @@ for instantiation.
 
 | Class | Plugin type | Source |
 |---|---|---|
-| `HiveMindPluginTypes` | enum of entry-point group names | `hivemind_plugin_manager/__init__.py:10` |
-| `DatabaseFactory` | creates `AbstractDB` / `AbstractRemoteDB` instances | `hivemind_plugin_manager/__init__.py:17` |
-| `AgentProtocolFactory` | creates `AgentProtocol` instances | `hivemind_plugin_manager/__init__.py:38` |
-| `NetworkProtocolFactory` | creates `NetworkProtocol` instances | `hivemind_plugin_manager/__init__.py:56` |
-| `BinaryDataHandlerProtocolFactory` | creates `BinaryDataHandlerProtocol` instances | `hivemind_plugin_manager/__init__.py:73` |
-| `find_plugins()` | discovers all installed plugins for a type | `hivemind_plugin_manager/__init__.py:108` |
-| `Client` | dataclass representing a connected device/credential | `hivemind_plugin_manager/database.py:35` |
-| `AbstractDB` | base class for local database plugins | `hivemind_plugin_manager/database.py:158` |
-| `AbstractRemoteDB` | base class for remote database plugins | `hivemind_plugin_manager/database.py:266` |
+| `HiveMindPluginTypes` | enum of entry-point group names | `hivemind_plugin_manager/__init__.py:13` |
+| `DatabaseFactory` | creates `AbstractDB` / `AbstractRemoteDB` instances | `hivemind_plugin_manager/__init__.py:21` |
+| `AgentProtocolFactory` | creates `AgentProtocol` instances | `hivemind_plugin_manager/__init__.py:42` |
+| `NetworkProtocolFactory` | creates `NetworkProtocol` instances | `hivemind_plugin_manager/__init__.py:60` |
+| `BinaryDataHandlerProtocolFactory` | creates `BinaryDataHandlerProtocol` instances | `hivemind_plugin_manager/__init__.py:77` |
+| `PolicyPluginFactory` | creates `PolicyPlugin` instances | `hivemind_plugin_manager/__init__.py:96` |
+| `find_plugins()` | discovers all installed plugins for a type | `hivemind_plugin_manager/__init__.py` |
+| `Client` | dataclass representing a connected device/credential | `hivemind_plugin_manager/database.py:36` |
+| `AbstractDB` | base class for local database plugins | `hivemind_plugin_manager/database.py:300` |
+| `AbstractRemoteDB` | base class for remote database plugins | `hivemind_plugin_manager/database.py:431` |
 | `AgentProtocol` | base class for agent protocol plugins | `hivemind_plugin_manager/protocols.py:61` |
 | `NetworkProtocol` | base class for network protocol plugins | `hivemind_plugin_manager/protocols.py:70` |
 | `BinaryDataHandlerProtocol` | base class for binary protocol plugins | `hivemind_plugin_manager/protocols.py:88` |
+| `PolicyPlugin` | base class for admission-control policy plugins | `hivemind_plugin_manager/policy.py:116` |
+| `Verdict` | return value of `PolicyPlugin.review(_binary)` | `hivemind_plugin_manager/policy.py:74` |
+| `Mutation` | abstract base for typed message mutations | `hivemind_plugin_manager/policy.py:47` |
 | `ClientCallbacks` | dataclass of lifecycle hooks | `hivemind_plugin_manager/protocols.py:27` |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -149,9 +149,11 @@ appended. See [HiveMind-core#85](https://github.com/JarbasHiveMind/HiveMind-core
 **Deprecated property shims** — `skill_blacklist` and `intent_blacklist` are read/write
 properties (`database.py:86`, `database.py:102`) backed by `Client.metadata`. Setting
 them emits `DeprecationWarning`; new code should write to `Client.metadata` directly.
-`message_blacklist` has no property — the field was removed because the admission model
-is whitelist-only. Legacy data for this key is preserved in `metadata` by the migration
-path in `deserialize` and the wrapped `__init__` (`database.py:249`).
+`message_blacklist` was removed outright (no property, no kwarg, no carry-forward). It
+was introduced 2024-12-20 in commit `94a2141` alongside the rename/multidb refactor but
+contradicted the deny-by-default whitelist model and never functioned as a real gate.
+`Client(message_blacklist=...)` raises `TypeError`; `deserialize` strips the key
+silently from on-disk records.
 
 **`metadata`** — free-form per-client dict for plugin-specific context. `deserialize`
 migrates legacy top-level blacklist keys into `metadata` automatically (`database.py:153`)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -149,11 +149,12 @@ appended. See [HiveMind-core#85](https://github.com/JarbasHiveMind/HiveMind-core
 **Deprecated property shims** — `skill_blacklist` and `intent_blacklist` are read/write
 properties (`database.py:86`, `database.py:102`) backed by `Client.metadata`. Setting
 them emits `DeprecationWarning`; new code should write to `Client.metadata` directly.
-`message_blacklist` was removed outright (no property, no kwarg, no carry-forward). It
+`message_blacklist` was removed from the data model (no property, no carry-forward). It
 was introduced 2024-12-20 in commit `94a2141` alongside the rename/multidb refactor but
 contradicted the deny-by-default whitelist model and never functioned as a real gate.
-`Client(message_blacklist=...)` raises `TypeError`; `deserialize` strips the key
-silently from on-disk records.
+The constructor kwarg is still accepted (for partial-upgrade safety with already-shipped
+backends) but the value is discarded with a `DeprecationWarning`; `deserialize` strips
+the key silently from on-disk records.
 
 **`metadata`** — free-form per-client dict for plugin-specific context. `deserialize`
 migrates legacy top-level blacklist keys into `metadata` automatically (`database.py:153`)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -10,13 +10,14 @@ All public symbols exported from `hivemind_plugin_manager`.
 
 ```python
 class HiveMindPluginTypes(str, enum.Enum):
-    DATABASE         = "hivemind.database"           # line 11
-    NETWORK_PROTOCOL = "hivemind.network.protocol"   # line 12
-    AGENT_PROTOCOL   = "hivemind.agent.protocol"     # line 13
-    BINARY_PROTOCOL  = "hivemind.binary.protocol"    # line 14
+    DATABASE         = "hivemind.database"           # line 14
+    NETWORK_PROTOCOL = "hivemind.network.protocol"   # line 15
+    AGENT_PROTOCOL   = "hivemind.agent.protocol"     # line 16
+    BINARY_PROTOCOL  = "hivemind.binary.protocol"    # line 17
+    POLICY           = "hivemind.policy"             # line 18
 ```
 
-Source: `hivemind_plugin_manager/__init__.py:10`
+Source: `hivemind_plugin_manager/__init__.py:13`
 
 Each value is the setuptools entry-point group string used for plugin discovery.
 
@@ -100,6 +101,23 @@ Raises `KeyError` if not found. Source: `__init__.py:76`
 
 ---
 
+### `PolicyPluginFactory`
+
+Source: `hivemind_plugin_manager/__init__.py:96`
+
+Discovers and instantiates policy plugins registered under `hivemind.policy`.
+Consumed by `hivemind-core`'s chain runner when assembling `policy.chain` at startup.
+
+#### `PolicyPluginFactory.get_class(plugin_name: str) -> Type[PolicyPlugin]`
+
+Raises `KeyError` if not found. Source: `__init__.py:103`
+
+#### `PolicyPluginFactory.create(plugin_name, config=None, hm_protocol=None) -> PolicyPlugin`
+
+`config` defaults to `{}` when `None`. Source: `__init__.py:110`
+
+---
+
 ## `hivemind_plugin_manager/database.py`
 
 ### `Client`
@@ -124,30 +142,37 @@ class Client:
     metadata: Dict[str, Any] = field(default_factory=dict)
 ```
 
-`__post_init__` (`database.py:52`) enforces int/bool types and populates `allowed_types`
-with a default OVOS message type set. `"recognizer_loop:utterance"` is always present.
+`__post_init__` (`database.py:56`) enforces int/bool types. `allowed_types` is **not**
+pre-populated — an empty list means deny-by-default. No automatic message types are
+appended. See [HiveMind-core#85](https://github.com/JarbasHiveMind/HiveMind-core/issues/85).
 
-**`metadata`** — free-form per-client dict for plugin-specific context. Stays out of
-the schema so individual plugins (auth, routing, telemetry, etc.) can attach arbitrary
-key/value data without growing the core dataclass. `deserialize` folds any unknown
-top-level keys from older records into `metadata` for forward compatibility; an
-explicit `metadata` key in the payload wins on collision. A non-dict `metadata` value
-raises `TypeError` in `deserialize` (intentional — signals upstream serializer bug).
+**Deprecated property shims** — `skill_blacklist` and `intent_blacklist` are read/write
+properties (`database.py:86`, `database.py:102`) backed by `Client.metadata`. Setting
+them emits `DeprecationWarning`; new code should write to `Client.metadata` directly.
+`message_blacklist` has no property — the field was removed because the admission model
+is whitelist-only. Legacy data for this key is preserved in `metadata` by the migration
+path in `deserialize` and the wrapped `__init__` (`database.py:249`).
+
+**`metadata`** — free-form per-client dict for plugin-specific context. `deserialize`
+migrates legacy top-level blacklist keys into `metadata` automatically (`database.py:153`)
+and folds any other unknown top-level keys from older records the same way; an explicit
+`metadata` key in the payload wins on collision. A non-dict `metadata` is coerced to
+`{}` in `__post_init__` (`database.py:70`).
 
 | Method | Signature | Source |
 |---|---|---|
-| `serialize()` | `-> str` (JSON) | `database.py:71` |
-| `deserialize(data)` | `staticmethod(str | dict) -> Client` | `database.py:81` |
-| `__getitem__(key)` | `-> Any`; raises `KeyError` | `database.py:96` |
-| `__setitem__(key, val)` | raises `ValueError` on unknown key | `database.py:113` |
-| `__eq__(other)` | compares serialized JSON | `database.py:129` |
-| `__repr__()` | returns `serialize()` | `database.py:147` |
+| `serialize()` | `-> str` (JSON) | `database.py:126` |
+| `deserialize(data)` | `staticmethod(str \| dict) -> Client` | `database.py:135` |
+| `__getitem__(key)` | `-> Any`; raises `KeyError` | `database.py:180` |
+| `__setitem__(key, val)` | raises `ValueError` on unknown key | `database.py:197` |
+| `__eq__(other)` | compares serialized JSON | `database.py:213` |
+| `__repr__()` | returns `serialize()` | `database.py:231` |
 
 ---
 
 ### `cast2client(ret: ClientTypes) -> Optional[Union[Client, List[Client]]]`
 
-Source: `hivemind_plugin_manager/database.py:15`
+Source: `hivemind_plugin_manager/database.py:16`
 
 Normalises `None`, `Client`, JSON string, dict, or list into `Client` instances. Raises
 `TypeError` for unsupported types.
@@ -156,7 +181,7 @@ Normalises `None`, `Client`, JSON string, dict, or list into `Client` instances.
 
 ### `AbstractDB`
 
-Source: `hivemind_plugin_manager/database.py:158`
+Source: `hivemind_plugin_manager/database.py:269`
 
 ```python
 @dataclass
@@ -182,7 +207,7 @@ class AbstractDB(abc.ABC):
 
 ### `AbstractRemoteDB`
 
-Source: `hivemind_plugin_manager/database.py:266`
+Source: `hivemind_plugin_manager/database.py:378`
 
 Extends `AbstractDB` with:
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -115,10 +115,7 @@ class Client:
     description: str = ""
     is_admin: bool = False   # must be bool
     last_seen: float = -1
-    intent_blacklist: List[str] = field(default_factory=list)
-    skill_blacklist: List[str] = field(default_factory=list)
-    message_blacklist: List[str] = field(default_factory=list)
-    allowed_types: List[str] = field(default_factory=list)
+    allowed_types: List[str] = field(default_factory=list)  # whitelist; empty = deny everything
     crypto_key: Optional[str] = None
     password: Optional[str] = None
     can_broadcast: bool = True

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -25,13 +25,13 @@ Each value is the setuptools entry-point group string used for plugin discovery.
 
 ### `find_plugins(plug_type=None) -> dict`
 
-Source: `hivemind_plugin_manager/__init__.py:108`
+Source: `hivemind_plugin_manager/__init__.py:136`
 
 Discovers all installed plugins matching `plug_type`.
 
 | Argument | Type | Behaviour |
 |---|---|---|
-| `None` | — | iterates all four `HiveMindPluginTypes` groups, merges results |
+| `None` | — | iterates every `HiveMindPluginTypes` group, merges results |
 | `HiveMindPluginTypes` member | enum | iterates that one group |
 | `str` | raw entry-point group name | iterates that group |
 
@@ -39,65 +39,65 @@ Returns `{plugin_name: class}`.
 
 Entry-point load failures are caught, logged once, and skipped. Already-errored entry
 points are stored in `find_plugins._errored` (a module-level list) to suppress repeated
-log noise. Source: `hivemind_plugin_manager/__init__.py:132`
+log noise.
 
 ---
 
 ### `DatabaseFactory`
 
-Source: `hivemind_plugin_manager/__init__.py:17`
+Source: `hivemind_plugin_manager/__init__.py:21`
 
 #### `DatabaseFactory.get_class(plugin_name: str) -> Type[AbstractDB]`
 
 Returns the class registered under `plugin_name` in `hivemind.database`.
-Raises `KeyError` if not found. Source: `__init__.py:19`
+Raises `KeyError` if not found. Source: `__init__.py:23`
 
 #### `DatabaseFactory.create(plugin_name, name="clients", subfolder="hivemind-core", password=None, host=None, port=None) -> Union[AbstractDB, AbstractRemoteDB]`
 
 Instantiates the plugin. If the class is a subclass of `AbstractRemoteDB`, `host` and
-`port` are forwarded; otherwise they are dropped. Source: `__init__.py:26`
+`port` are forwarded; otherwise they are dropped. Source: `__init__.py:30`
 
 ---
 
 ### `AgentProtocolFactory`
 
-Source: `hivemind_plugin_manager/__init__.py:38`
+Source: `hivemind_plugin_manager/__init__.py:42`
 
 #### `AgentProtocolFactory.get_class(plugin_name: str) -> Type[AgentProtocol]`
 
-Raises `KeyError` if not found. Source: `__init__.py:40`
+Raises `KeyError` if not found. Source: `__init__.py:44`
 
 #### `AgentProtocolFactory.create(plugin_name, config=None, bus=None, hm_protocol=None) -> AgentProtocol`
 
-`config` defaults to `{}` when `None`. Source: `__init__.py:47`
+`config` defaults to `{}` when `None`. Source: `__init__.py:51`
 
 ---
 
 ### `NetworkProtocolFactory`
 
-Source: `hivemind_plugin_manager/__init__.py:56`
+Source: `hivemind_plugin_manager/__init__.py:60`
 
 #### `NetworkProtocolFactory.get_class(plugin_name: str) -> Type[NetworkProtocol]`
 
-Raises `KeyError` if not found. Source: `__init__.py:58`
+Raises `KeyError` if not found. Source: `__init__.py:62`
 
 #### `NetworkProtocolFactory.create(plugin_name, config=None, hm_protocol=None) -> NetworkProtocol`
 
-`config` defaults to `{}` when `None`. Source: `__init__.py:64`
+`config` defaults to `{}` when `None`. Source: `__init__.py:69`
 
 ---
 
 ### `BinaryDataHandlerProtocolFactory`
 
-Source: `hivemind_plugin_manager/__init__.py:73`
+Source: `hivemind_plugin_manager/__init__.py:77`
 
 #### `BinaryDataHandlerProtocolFactory.get_class(plugin_name: str) -> Type[BinaryDataHandlerProtocol]`
 
-Raises `KeyError` if not found. Source: `__init__.py:76`
+Raises `KeyError` if not found. Source: `__init__.py:80`
 
 #### `BinaryDataHandlerProtocolFactory.create(plugin_name, config=None, hm_protocol=None, agent_protocol=None) -> BinaryDataHandlerProtocol`
 
-`config` defaults to `{}` when `None`. Source: `__init__.py:83`
+`config` defaults to `{}` when `None`. Source: `__init__.py:87`
 
 ---
 
@@ -165,11 +165,11 @@ and folds any other unknown top-level keys from older records the same way; an e
 | Method | Signature | Source |
 |---|---|---|
 | `serialize()` | `-> str` (JSON) | `database.py:126` |
-| `deserialize(data)` | `staticmethod(str \| dict) -> Client` | `database.py:135` |
-| `__getitem__(key)` | `-> Any`; raises `KeyError` | `database.py:180` |
-| `__setitem__(key, val)` | raises `ValueError` on unknown key | `database.py:197` |
-| `__eq__(other)` | compares serialized JSON | `database.py:213` |
-| `__repr__()` | returns `serialize()` | `database.py:231` |
+| `deserialize(data)` | `staticmethod(str \| dict) -> Client` | `database.py:136` |
+| `__getitem__(key)` | `-> Any`; raises `KeyError` | `database.py:189` |
+| `__setitem__(key, val)` | raises `ValueError` on unknown key | `database.py:206` |
+| `__eq__(other)` | compares serialized JSON | `database.py:222` |
+| `__repr__()` | returns `serialize()` | `database.py:240` |
 
 ---
 
@@ -184,7 +184,7 @@ Normalises `None`, `Client`, JSON string, dict, or list into `Client` instances.
 
 ### `AbstractDB`
 
-Source: `hivemind_plugin_manager/database.py:269`
+Source: `hivemind_plugin_manager/database.py:300`
 
 ```python
 @dataclass
@@ -192,25 +192,31 @@ class AbstractDB(abc.ABC):
     name: str = "clients"
     subfolder: str = "hivemind-core"
     password: Optional[str] = None
+
+    SCHEMA_VERSION: ClassVar[int] = 2  # bumped 2024-05 for legacy-blacklist purge
 ```
 
 | Method | Abstract | Signature | Source |
 |---|---|---|---|
-| `add_item` | yes | `(client: Client) -> bool` | `database.py:169` |
-| `search_by_value` | yes | `(key: str, val) -> List[Client]` | `database.py:221` |
-| `__len__` | yes | `() -> int` | `database.py:234` |
-| `__iter__` | yes | `() -> Iterable[Client]` | `database.py:243` |
-| `delete_item` | no | `(client) -> bool` — tombstone pattern | `database.py:181` |
-| `update_item` | no | `(client) -> bool` — calls `add_item` | `database.py:195` |
-| `replace_item` | no | `(old, new) -> bool` | `database.py:207` |
-| `sync` | no | `()` — no-op | `database.py:252` |
-| `commit` | no | `() -> True` | `database.py:256` |
+| `add_item` | yes | `(client: Client) -> bool` | `database.py:312` |
+| `search_by_value` | yes | `(key: str, val) -> List[Client]` | `database.py:364` |
+| `__len__` | yes | `() -> int` | `database.py:377` |
+| `__iter__` | yes | `() -> Iterable[Client]` | `database.py:386` |
+| `delete_item` | no | `(client) -> bool` — tombstone pattern | `database.py:323` |
+| `update_item` | no | `(client) -> bool` — calls `add_item` | `database.py:337` |
+| `replace_item` | no | `(old, new) -> bool` | `database.py:349` |
+| `sync` | no | `()` — no-op | `database.py:394` |
+| `migrate` | no | `(from_version: int) -> None` — schema migration hook (default no-op); backends override for their persisted on-disk shape | `database.py:405` |
+| `commit` | no | `() -> True` | `database.py:420` |
+
+See [Concepts → Database Schema Migration](concepts.md#database-schema-migration)
+for the `SCHEMA_VERSION` + `migrate()` contract.
 
 ---
 
 ### `AbstractRemoteDB`
 
-Source: `hivemind_plugin_manager/database.py:378`
+Source: `hivemind_plugin_manager/database.py:431`
 
 Extends `AbstractDB` with:
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -149,12 +149,10 @@ appended. See [HiveMind-core#85](https://github.com/JarbasHiveMind/HiveMind-core
 **Deprecated property shims** — `skill_blacklist` and `intent_blacklist` are read/write
 properties (`database.py:86`, `database.py:102`) backed by `Client.metadata`. Setting
 them emits `DeprecationWarning`; new code should write to `Client.metadata` directly.
-`message_blacklist` was removed from the data model (no property, no carry-forward). It
-was introduced 2024-12-20 in commit `94a2141` alongside the rename/multidb refactor but
-contradicted the deny-by-default whitelist model and never functioned as a real gate.
-The constructor kwarg is still accepted (for partial-upgrade safety with already-shipped
-backends) but the value is discarded with a `DeprecationWarning`; `deserialize` strips
-the key silently from on-disk records.
+`message_blacklist` is not part of the data model: no property, no metadata
+carry-forward. The constructor kwarg is accepted-and-discarded with a
+`DeprecationWarning`, and `deserialize` strips the top-level key silently from on-disk
+records.
 
 **`metadata`** — free-form per-client dict for plugin-specific context. `deserialize`
 migrates legacy top-level blacklist keys into `metadata` automatically (`database.py:153`)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -154,16 +154,18 @@ Notable rules enforced in `__post_init__` (`database.py:56`):
 `skill_blacklist` and `intent_blacklist` are **deprecated property shims** (`database.py:86`,
 `database.py:102`) that read and write `Client.metadata["skill_blacklist"]` /
 `Client.metadata["intent_blacklist"]` transparently. Setting them emits
-`DeprecationWarning`. `message_blacklist` was removed outright — it was introduced
-2024-12-20 alongside legitimate ACL work but contradicted the deny-by-default whitelist
-model and never functioned as a real gate. No property, no kwarg, no carry-forward.
+`DeprecationWarning`. `message_blacklist` was removed from the data model — it was
+introduced 2024-12-20 (commit `94a2141`) alongside legitimate ACL work but contradicted
+the deny-by-default whitelist model and never functioned as a real gate. No property,
+no carry-forward into `metadata`.
 
 **Legacy constructor kwargs** (`skill_blacklist`, `intent_blacklist`) are accepted via a
 wrapped `__init__` (`database.py:249`) and auto-migrated into `metadata` with a
-`DeprecationWarning`. `message_blacklist` is also accepted — but the value is
-**discarded** with a `DeprecationWarning`, not carried into `metadata`. The kwarg
-surface stays back-compat so already-shipped backends (notably the pre-release SQLite
-plugin) don't crash on partial HPM upgrades.
+`DeprecationWarning`. `message_blacklist` is also accepted at the kwarg surface (so
+already-shipped backends — notably the pre-release SQLite plugin's `_row_to_client` —
+don't crash on partial HPM upgrades) but the value is **discarded** with a
+`DeprecationWarning`. Net effect: callers can keep passing the kwarg during the
+upgrade window, but the data is dropped.
 
 ### `metadata` — plugin-specific extension point
 
@@ -214,6 +216,34 @@ by overriding it.
 The legacy field names map 1:1 to keys under `metadata` — this is what the
 `Client.skill_blacklist` etc. property shims read from
 (`database.py:87`–`140`).
+
+### Partial-upgrade safety
+
+HPM, the backends, and `hivemind-core` can be merged and released independently.
+Every combination is supported during the upgrade window:
+
+- **New HPM + old backends.** The wrapped `__init__` accepts every legacy kwarg
+  (`skill_blacklist`, `intent_blacklist`, `message_blacklist`) so pre-release
+  backends that pass those positionally don't crash. `skill_blacklist` and
+  `intent_blacklist` migrate into `metadata` with a `DeprecationWarning`;
+  `message_blacklist` is discarded with a `DeprecationWarning` (no
+  carry-forward). `Client.deserialize` strips the same three keys from on-disk
+  records the same way.
+- **Old HPM + new backends.** Each backend gates its `migrate()` call on
+  `getattr(AbstractDB, "SCHEMA_VERSION", 1)`, so if the constant is missing
+  the backend treats the on-disk shape as already-at-target and skips
+  migration. On-disk rows continue to carry the legacy keys; reads still
+  succeed because the backend's `_row_to_client` path doesn't depend on the
+  new contract.
+- **Mixed backend versions.** Each backend tracks its own schema version
+  natively (SQLite `PRAGMA user_version`, Redis sentinel key, JsonDB sibling
+  file). Migrating one backend has no effect on the others.
+
+The cost of this safety is that a `message_blacklist` value passed via the
+constructor kwarg silently disappears, with only a `DeprecationWarning` to
+flag it. Callers should stop passing the kwarg; it is no longer load-bearing.
+
+---
 
 Existing third-party backends that don't override `migrate()` continue to
 work — they just won't clean up legacy on-disk shape. The

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -183,6 +183,41 @@ signalling an upstream serializer bug via a missing-key outcome rather than a cr
 
 ---
 
+## Database Schema Migration
+
+`AbstractDB` declares a `SCHEMA_VERSION: ClassVar[int]` constant (currently
+`2`) and a non-abstract `migrate(self, from_version: int)` hook
+(`database.py:368`). The default implementation is a no-op; backends opt in
+by overriding it.
+
+**Contract for backend authors:**
+
+1. Persist the current schema version somewhere backend-native — `PRAGMA
+   user_version` for SQLite, a sentinel key (`hivemind:schema_version`) for
+   Redis, a top-level `__schema_version__` field for JSON files, etc.
+2. At backend init (typically `__post_init__`), read the persisted version;
+   if it is lower than `AbstractDB.SCHEMA_VERSION`, call
+   `self.migrate(from_version=stored)` and then write the new version.
+3. `migrate()` MUST be **idempotent and crash-safe**. A partial migration
+   interrupted by a crash must produce the same final state when re-run.
+
+**Migration matrix:**
+
+| from → to | What the backend must do |
+|---|---|
+| `1 → 2` | Move legacy top-level OVOS blacklist fields (`skill_blacklist`, `intent_blacklist`, `message_blacklist`) into each `Client.metadata` dict (`setdefault` — never clobber an explicit metadata value), then drop the legacy storage. The `Client.metadata` shape is `{"skill_blacklist": [...], "intent_blacklist": [...], "message_blacklist": [...]}`. |
+
+The legacy field names map 1:1 to keys under `metadata` — this is what the
+`Client.skill_blacklist` etc. property shims read from
+(`database.py:87`–`140`).
+
+Existing third-party backends that don't override `migrate()` continue to
+work — they just won't clean up legacy on-disk shape. The
+`@property` shims on `Client` ensure read-path code keeps functioning
+regardless of whether migration has run.
+
+---
+
 ## `_SubProtocol` Base
 
 All three protocol base classes (`AgentProtocol`, `NetworkProtocol`,

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -160,7 +160,10 @@ model and never functioned as a real gate. No property, no kwarg, no carry-forwa
 
 **Legacy constructor kwargs** (`skill_blacklist`, `intent_blacklist`) are accepted via a
 wrapped `__init__` (`database.py:249`) and auto-migrated into `metadata` with a
-`DeprecationWarning`. `Client(message_blacklist=...)` raises `TypeError`.
+`DeprecationWarning`. `message_blacklist` is also accepted — but the value is
+**discarded** with a `DeprecationWarning`, not carried into `metadata`. The kwarg
+surface stays back-compat so already-shipped backends (notably the pre-release SQLite
+plugin) don't crash on partial HPM upgrades.
 
 ### `metadata` — plugin-specific extension point
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -147,9 +147,10 @@ Notable rules enforced in `__post_init__` (`database.py:56`):
 - `client_id` must be `int` — raises `ValueError` otherwise.
 - `is_admin` must be `bool` — raises `ValueError` otherwise.
 - `allowed_types` is **not** pre-populated. An empty list means the client cannot inject
-  any message type (deny-by-default). Operators grant access explicitly via
-  `hivemind-core allow-msg <type> <id>` or by passing `allowed_types=[...]` on
-  construction. See [HiveMind-core#85](https://github.com/JarbasHiveMind/HiveMind-core/issues/85).
+  any message type (deny-by-default). The consumer that enforces this (typically
+  `hivemind-core`) decides how operators grant access — HPM only owns the data shape.
+  See [HiveMind-core#85](https://github.com/JarbasHiveMind/HiveMind-core/issues/85)
+  for the admission-chain design that consumes this field.
 
 `skill_blacklist` and `intent_blacklist` are **deprecated property shims** (`database.py:86`,
 `database.py:102`) that read and write `Client.metadata["skill_blacklist"]` /

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -154,13 +154,13 @@ Notable rules enforced in `__post_init__` (`database.py:56`):
 `skill_blacklist` and `intent_blacklist` are **deprecated property shims** (`database.py:86`,
 `database.py:102`) that read and write `Client.metadata["skill_blacklist"]` /
 `Client.metadata["intent_blacklist"]` transparently. Setting them emits
-`DeprecationWarning`. `message_blacklist` no longer has a property at all — the field was
-removed because hivemind-core is whitelist-only (deny-by-default); any legacy data for
-this key survives in `metadata` for third-party plugin consumption.
+`DeprecationWarning`. `message_blacklist` was removed outright — it was introduced
+2024-12-20 alongside legitimate ACL work but contradicted the deny-by-default whitelist
+model and never functioned as a real gate. No property, no kwarg, no carry-forward.
 
-**Legacy constructor kwargs** (`skill_blacklist`, `intent_blacklist`, `message_blacklist`)
-are accepted via a wrapped `__init__` (`database.py:249`) and auto-migrated into
-`metadata` with a `DeprecationWarning`.
+**Legacy constructor kwargs** (`skill_blacklist`, `intent_blacklist`) are accepted via a
+wrapped `__init__` (`database.py:249`) and auto-migrated into `metadata` with a
+`DeprecationWarning`. `Client(message_blacklist=...)` raises `TypeError`.
 
 ### `metadata` — plugin-specific extension point
 
@@ -171,10 +171,11 @@ adding new top-level fields to the core dataclass.
 `Client.deserialize` (`database.py:135`) is forward-compatible with older records in two
 ways:
 
-- **Legacy blacklist fields** (`skill_blacklist`, `intent_blacklist`, `message_blacklist`)
-  found as top-level JSON keys are silently migrated into `metadata` with a
-  `DeprecationWarning`, so existing on-disk JSON databases keep loading without manual
-  migration. Source: `database.py:153`.
+- **Legacy blacklist fields** (`skill_blacklist`, `intent_blacklist`) found as top-level
+  JSON keys are silently migrated into `metadata` with a `DeprecationWarning`, so
+  existing on-disk JSON databases keep loading without manual migration. Source:
+  `database.py:153`. **`message_blacklist`** top-level keys are dropped silently — the
+  field is gone for good and the data is not carried forward.
 - **Any other unknown top-level key** is folded into `metadata` so plugin-added fields
   do not break deserialization. Explicit `metadata` dict entries win on collision.
 
@@ -205,7 +206,7 @@ by overriding it.
 
 | from → to | What the backend must do |
 |---|---|
-| `1 → 2` | Move legacy top-level OVOS blacklist fields (`skill_blacklist`, `intent_blacklist`, `message_blacklist`) into each `Client.metadata` dict (`setdefault` — never clobber an explicit metadata value), then drop the legacy storage. The `Client.metadata` shape is `{"skill_blacklist": [...], "intent_blacklist": [...], "message_blacklist": [...]}`. |
+| `1 → 2` | Move legacy top-level OVOS blacklist fields (`skill_blacklist`, `intent_blacklist`) into each `Client.metadata` dict (`setdefault` — never clobber an explicit metadata value), then drop the legacy storage. **`message_blacklist`** is dropped without carry-forward (the field was removed from the data model entirely; backends MAY still persist it in `metadata` if they like, but it is no longer a load-bearing key). |
 
 The legacy field names map 1:1 to keys under `metadata` — this is what the
 `Client.skill_blacklist` etc. property shims read from

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -64,7 +64,7 @@ Return value is `{plugin_name: class}`.
 
 Key behaviours:
 
-- Passing `None` iterates **all four** entry-point groups and merges the results.
+- Passing `None` iterates **all five** entry-point groups (database, agent protocol, network protocol, binary protocol, policy) and merges the results.
 - Passing a string (e.g. `"hivemind.database"`) is also accepted.
 - If a plugin's `load()` raises, the error is logged once and the entry point is skipped;
   the dict simply will not contain that name. This is the **error-swallowing** behaviour

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -129,10 +129,7 @@ class Client:
     description: str = ""
     is_admin: bool = False
     last_seen: float = -1
-    intent_blacklist: List[str] = field(default_factory=list)
-    skill_blacklist: List[str] = field(default_factory=list)
-    message_blacklist: List[str] = field(default_factory=list)
-    allowed_types: List[str] = field(default_factory=list)
+    allowed_types: List[str] = field(default_factory=list)  # admission whitelist; deny-by-default
     crypto_key: Optional[str] = None
     password: Optional[str] = None
     can_broadcast: bool = True

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -155,18 +155,17 @@ Notable rules enforced in `__post_init__` (`database.py:56`):
 `skill_blacklist` and `intent_blacklist` are **deprecated property shims** (`database.py:86`,
 `database.py:102`) that read and write `Client.metadata["skill_blacklist"]` /
 `Client.metadata["intent_blacklist"]` transparently. Setting them emits
-`DeprecationWarning`. `message_blacklist` was removed from the data model — it was
-introduced 2024-12-20 (commit `94a2141`) alongside legitimate ACL work but contradicted
-the deny-by-default whitelist model and never functioned as a real gate. No property,
-no carry-forward into `metadata`.
+`DeprecationWarning`. `message_blacklist` is not part of the `Client` data model — no
+property, no metadata carry-forward.
 
-**Legacy constructor kwargs** (`skill_blacklist`, `intent_blacklist`) are accepted via a
-wrapped `__init__` (`database.py:249`) and auto-migrated into `metadata` with a
-`DeprecationWarning`. `message_blacklist` is also accepted at the kwarg surface (so
-already-shipped backends — notably the pre-release SQLite plugin's `_row_to_client` —
-don't crash on partial HPM upgrades) but the value is **discarded** with a
-`DeprecationWarning`. Net effect: callers can keep passing the kwarg during the
-upgrade window, but the data is dropped.
+**Legacy constructor kwargs** are accepted via a wrapped `__init__`
+(`database.py:249`):
+
+- `skill_blacklist`, `intent_blacklist`: auto-migrated into `metadata` with a
+  `DeprecationWarning`.
+- `message_blacklist`: accepted and discarded with a `DeprecationWarning`; the value
+  is dropped. (The kwarg surface stays so backends passing it positionally don't
+  crash.)
 
 ### `metadata` — plugin-specific extension point
 
@@ -218,31 +217,25 @@ The legacy field names map 1:1 to keys under `metadata` — this is what the
 `Client.skill_blacklist` etc. property shims read from
 (`database.py:87`–`140`).
 
-### Partial-upgrade safety
+### Cross-package compatibility
 
-HPM, the backends, and `hivemind-core` can be merged and released independently.
-Every combination is supported during the upgrade window:
+HPM, the database backends, and `hivemind-core` ship and version independently.
+The contract surface that makes this work:
 
-- **New HPM + old backends.** The wrapped `__init__` accepts every legacy kwarg
-  (`skill_blacklist`, `intent_blacklist`, `message_blacklist`) so pre-release
-  backends that pass those positionally don't crash. `skill_blacklist` and
-  `intent_blacklist` migrate into `metadata` with a `DeprecationWarning`;
-  `message_blacklist` is discarded with a `DeprecationWarning` (no
-  carry-forward). `Client.deserialize` strips the same three keys from on-disk
-  records the same way.
-- **Old HPM + new backends.** Each backend gates its `migrate()` call on
-  `getattr(AbstractDB, "SCHEMA_VERSION", 1)`, so if the constant is missing
-  the backend treats the on-disk shape as already-at-target and skips
-  migration. On-disk rows continue to carry the legacy keys; reads still
-  succeed because the backend's `_row_to_client` path doesn't depend on the
-  new contract.
-- **Mixed backend versions.** Each backend tracks its own schema version
-  natively (SQLite `PRAGMA user_version`, Redis sentinel key, JsonDB sibling
-  file). Migrating one backend has no effect on the others.
+- `Client.__init__` accepts the legacy kwargs `skill_blacklist`,
+  `intent_blacklist`, and `message_blacklist`. The first two are migrated into
+  `metadata` with a `DeprecationWarning`; the third is discarded with a
+  `DeprecationWarning`. `Client.deserialize` applies the same rules to
+  top-level keys in on-disk records.
+- Backend `migrate()` implementations gate on
+  `getattr(AbstractDB, "SCHEMA_VERSION", 1)`, so a backend can run against any
+  HPM — missing constant ⇒ skip migration.
+- Each backend tracks its own schema version natively (SQLite
+  `PRAGMA user_version`, Redis sentinel key, JsonDB sibling file). Backends
+  migrate independently.
 
-The cost of this safety is that a `message_blacklist` value passed via the
-constructor kwarg silently disappears, with only a `DeprecationWarning` to
-flag it. Callers should stop passing the kwarg; it is no longer load-bearing.
+`message_blacklist` values passed via the constructor kwarg disappear with a
+`DeprecationWarning`. Callers should not pass this kwarg.
 
 ---
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -2,7 +2,7 @@
 
 ## Plugin Types
 
-HPM defines four plugin types as string-valued enum members.
+HPM defines five plugin types as string-valued enum members.
 
 ```python
 class HiveMindPluginTypes(str, enum.Enum):
@@ -10,9 +10,10 @@ class HiveMindPluginTypes(str, enum.Enum):
     NETWORK_PROTOCOL = "hivemind.network.protocol"
     AGENT_PROTOCOL   = "hivemind.agent.protocol"
     BINARY_PROTOCOL  = "hivemind.binary.protocol"
+    POLICY           = "hivemind.policy"
 ```
 
-Source: `hivemind_plugin_manager/__init__.py:10`
+Source: `hivemind_plugin_manager/__init__.py:13`
 
 Each value is the setuptools entry-point group name that plugin packages must use.
 
@@ -83,8 +84,9 @@ Each plugin type has a corresponding factory with two class methods:
 | `AgentProtocolFactory` | `Type[AgentProtocol]` | `AgentProtocol` |
 | `NetworkProtocolFactory` | `Type[NetworkProtocol]` | `NetworkProtocol` |
 | `BinaryDataHandlerProtocolFactory` | `Type[BinaryDataHandlerProtocol]` | `BinaryDataHandlerProtocol` |
+| `PolicyPluginFactory` | `Type[PolicyPlugin]` | `PolicyPlugin` |
 
-Source: `hivemind_plugin_manager/__init__.py:17–89`
+Source: `hivemind_plugin_manager/__init__.py:21–115`
 
 `get_class` raises `KeyError` with a helpful message listing available plugins when the
 requested name is not installed. `create` calls `get_class` then instantiates with the
@@ -129,7 +131,7 @@ class Client:
     description: str = ""
     is_admin: bool = False
     last_seen: float = -1
-    allowed_types: List[str] = field(default_factory=list)  # admission whitelist; deny-by-default
+    allowed_types: List[str] = field(default_factory=list)  # admission whitelist; empty = deny everything
     crypto_key: Optional[str] = None
     password: Optional[str] = None
     can_broadcast: bool = True
@@ -140,13 +142,25 @@ class Client:
 
 Source: `hivemind_plugin_manager/database.py:35`
 
-Notable rules enforced in `__post_init__` (`database.py:52`):
+Notable rules enforced in `__post_init__` (`database.py:56`):
 
 - `client_id` must be `int` — raises `ValueError` otherwise.
 - `is_admin` must be `bool` — raises `ValueError` otherwise.
-- `allowed_types` is populated with a default set of OVOS message types when empty.
-- `"recognizer_loop:utterance"` is always appended to `allowed_types` even if the caller
-  provides a custom list.
+- `allowed_types` is **not** pre-populated. An empty list means the client cannot inject
+  any message type (deny-by-default). Operators grant access explicitly via
+  `hivemind-core allow-msg <type> <id>` or by passing `allowed_types=[...]` on
+  construction. See [HiveMind-core#85](https://github.com/JarbasHiveMind/HiveMind-core/issues/85).
+
+`skill_blacklist` and `intent_blacklist` are **deprecated property shims** (`database.py:86`,
+`database.py:102`) that read and write `Client.metadata["skill_blacklist"]` /
+`Client.metadata["intent_blacklist"]` transparently. Setting them emits
+`DeprecationWarning`. `message_blacklist` no longer has a property at all — the field was
+removed because hivemind-core is whitelist-only (deny-by-default); any legacy data for
+this key survives in `metadata` for third-party plugin consumption.
+
+**Legacy constructor kwargs** (`skill_blacklist`, `intent_blacklist`, `message_blacklist`)
+are accepted via a wrapped `__init__` (`database.py:249`) and auto-migrated into
+`metadata` with a `DeprecationWarning`.
 
 ### `metadata` — plugin-specific extension point
 
@@ -154,12 +168,18 @@ Notable rules enforced in `__post_init__` (`database.py:52`):
 context (routing hints, auth metadata, feature flags, telemetry tags, etc.) without
 adding new top-level fields to the core dataclass.
 
-`Client.deserialize` (`database.py:81`) is forward-compatible with older records:
-unknown top-level keys are folded into `metadata` automatically, so a plugin can
-freely add new keys without breaking deserialisation of existing rows. If both an
-explicit `metadata` dict and a stray legacy key exist with the same name, the
-explicit one wins. A non-dict `metadata` value raises `TypeError` — intentional,
-because silently coercing it would mask serializer bugs upstream.
+`Client.deserialize` (`database.py:135`) is forward-compatible with older records in two
+ways:
+
+- **Legacy blacklist fields** (`skill_blacklist`, `intent_blacklist`, `message_blacklist`)
+  found as top-level JSON keys are silently migrated into `metadata` with a
+  `DeprecationWarning`, so existing on-disk JSON databases keep loading without manual
+  migration. Source: `database.py:153`.
+- **Any other unknown top-level key** is folded into `metadata` so plugin-added fields
+  do not break deserialization. Explicit `metadata` dict entries win on collision.
+
+A non-dict `metadata` value in `__post_init__` is coerced to `{}` (`database.py:70`),
+signalling an upstream serializer bug via a missing-key outcome rather than a crash.
 
 ---
 

--- a/docs/plugins/policy.md
+++ b/docs/plugins/policy.md
@@ -1,0 +1,242 @@
+# Policy Plugin Guide
+
+A **policy plugin** is HiveMind's admission-control point: it sees every
+Mycroft `Message` (and every binary payload) about to be forwarded to the
+agent bus, and can **allow** it, **deny** it, or **mutate** it. Multiple
+policies form a chain, executed in an operator-declared order.
+
+Policies are the mechanism for dynamic ACL checks that depend on
+current server state — per-API-key quotas, rate limits, parental
+controls, audit logs, sensitive-intent confirmation. Static ACLs that
+live on the `Client` record (allowed_types, blacklists) are themselves
+expressed as built-in policy plugins by `hivemind-core`.
+
+> Architecture context: see
+> [HiveMind-core#85](https://github.com/JarbasHiveMind/HiveMind-core/issues/85).
+> This document covers the **plugin author** surface defined in
+> `hivemind-plugin-manager`. The chain runner that consumes these
+> plugins lives in `hivemind-core`.
+
+---
+
+## Base Class
+
+```python
+@dataclass
+class PolicyPlugin(_SubProtocol):
+    """Base class for HiveMind policy plugins.
+
+    Subclasses override review (and optionally review_binary / observe).
+    They are loaded by hivemind-core via the hivemind.policy
+    entry-point group and invoked in the order declared by the
+    operator's policy.chain config.
+    """
+    config: Dict[str, Any] = dataclasses.field(default_factory=dict)
+    hm_protocol: Optional['HiveMindListenerProtocol'] = None
+
+    def review(self, message, client) -> Verdict: ...
+    def review_binary(self, payload, client) -> Verdict: ...
+    def observe(self, message, client) -> None: ...
+```
+
+Source: `hivemind_plugin_manager/policy.py`.
+
+`PolicyPlugin` extends `_SubProtocol`
+(`protocols.py:35`), which provides `.identity`, `.database`, and
+`.clients` properties — see [Concepts](../concepts.md#_subprotocol-base).
+
+---
+
+## Hooks
+
+| Method | Called when | Default impl |
+|---|---|---|
+| `review(message, client)` | A Mycroft `Message` is about to be forwarded to the agent bus. | Returns `Verdict.allow()`. |
+| `review_binary(payload, client)` | A binary payload (e.g. raw audio) is about to be forwarded. | Returns `Verdict.allow()`. |
+| `observe(message, client)` | A message was successfully emitted to the bus. Use for counters, audit logs, telemetry. | No-op. |
+
+All three are **synchronous**. The chain runner in `hivemind-core` is
+synchronous; introducing an async variant would require a coordinated
+change across `hivemind-plugin-manager`, `hivemind-core`, and every
+agent protocol — out of scope for this contract.
+
+**Failure semantics** (enforced by the chain runner, not the plugin):
+
+- Unhandled exception in `review` / `review_binary` → treated as
+  `Verdict.deny("policy_error", reason="policy crashed")`. Fail-closed.
+- Unhandled exception in `observe` → logged and swallowed. Observation
+  never blocks delivery.
+- Unhandled exception in a `Mutation.apply` → logged and skipped; the
+  message proceeds with whatever mutations did apply.
+
+---
+
+## `Verdict`
+
+The return value of `review()` and `review_binary()`.
+
+```python
+@dataclass
+class Verdict:
+    denied: bool = False
+    code: str = ""
+    reason: str = ""
+    data: Dict[str, Any] = field(default_factory=dict)
+    mutations: List[Mutation] = field(default_factory=list)
+
+    @classmethod
+    def allow(cls, *mutations: Mutation) -> "Verdict": ...
+    @classmethod
+    def deny(cls, code: str, reason: str = "", **data: Any) -> "Verdict": ...
+```
+
+A verdict is either denying or allowing-with-mutations:
+
+```python
+# Allow, no changes
+return Verdict.allow()
+
+# Allow, with mutations
+return Verdict.allow(
+    AddBlacklistedSkill("adult.skill"),
+    SetSessionField("filter_level", "family"),
+)
+
+# Deny — short-circuits the chain
+return Verdict.deny(
+    "quota_exceeded",
+    "daily limit of 100 reached",
+    limit=100, used=100, window="1d",
+)
+```
+
+`code` is a **stable, machine-readable** string clients can switch on
+(`"quota_exceeded"`, `"intent_blacklisted"`, `"policy_error"`). `reason`
+is human-readable. Extra keyword arguments go into `data`, which the
+chain runner forwards to the client as part of the `hive.policy.denied`
+notification message.
+
+Mutations attached to a *denying* verdict are ignored.
+
+---
+
+## `Mutation`
+
+Typed actions a policy can request on a message being allowed. Adding
+new mutation kinds is the explicit, greppable way to extend what
+policies are allowed to change — there is no free-form dict-merge
+mutation by design.
+
+| Class | Effect |
+|---|---|
+| `AddBlacklistedSkill(skill_id)` | Appends to `message.context["session"]["blacklisted_skills"]`. |
+| `AddBlacklistedIntent(intent_name)` | Appends to `message.context["session"]["blacklisted_intents"]`. |
+| `AddBlacklistedMessageType(msg_type)` | Appends to `message.context["session"]["blacklisted_message_types"]`. |
+| `SetSessionField(key, value)` | Sets one key in `message.context["session"]`. |
+| `SetContextField(path, value)` | Sets a nested key in `message.context` (tuple-typed path). |
+| `RewriteUtterance(text)` | Replaces `data["utterances"]` on a `recognizer_loop:utterance` message. Silent no-op on any other `msg_type`. |
+
+All mutations are idempotent on list mutations (no duplicates) and
+robust to non-dict context/session values (they coerce). Source:
+`hivemind_plugin_manager/policy.py`.
+
+If you need a new mutation kind, add it here in
+`hivemind-plugin-manager` rather than as a free-form mechanism in your
+plugin — the chain runner is meant to know what plugins are allowed to
+change.
+
+---
+
+## Registering a plugin
+
+In your package's `setup.py` / `pyproject.toml`, register under
+`hivemind.policy`:
+
+```toml
+[project.entry-points."hivemind.policy"]
+"hivemind-intent-quota-policy" = "hivemind_intent_quota:IntentQuotaPolicy"
+```
+
+Operators then enable your policy in `hivemind-core`'s `policy` config
+block:
+
+```json
+{
+  "policy": {
+    "chain": [
+      "hivemind-client-acl-policy",
+      "hivemind-intent-quota-policy"
+    ],
+    "hivemind-intent-quota-policy": {
+      "per_day": 1000,
+      "redis_url": "redis://localhost:6379/0"
+    }
+  }
+}
+```
+
+---
+
+## Example: intent quota plugin
+
+A small, realistic policy that tracks per-account utterance counts in
+Redis and denies once a daily limit is reached. Uses `Client.metadata`
+(see [Database](database.md)) to group counters by `account_id`, so a
+deployment can have multiple HiveMind clients sharing one quota.
+
+```python
+from hivemind_plugin_manager import PolicyPlugin, Verdict
+
+
+class IntentQuotaPolicy(PolicyPlugin):
+    def __init__(self, config, hm_protocol=None):
+        super().__init__(config=config, hm_protocol=hm_protocol)
+        self.per_day = config.get("per_day", 1000)
+        self.store = RedisCounter(config["redis_url"])
+
+    def review(self, message, client):
+        if message.msg_type != "recognizer_loop:utterance":
+            return Verdict.allow()
+        account = client.user.metadata.get("account_id") or client.key
+        used = self.store.get(account, window="1d")
+        if used >= self.per_day:
+            return Verdict.deny(
+                "quota_exceeded",
+                f"daily limit {self.per_day} reached",
+                limit=self.per_day, used=used,
+            )
+        return Verdict.allow()
+
+    def observe(self, message, client):
+        # Only count messages that were actually emitted to the bus —
+        # denials don't increment the counter.
+        if message.msg_type != "recognizer_loop:utterance":
+            return
+        account = client.user.metadata.get("account_id") or client.key
+        self.store.incr(account, window="1d")
+```
+
+That's the whole plugin: ~20 lines. The chain runner handles the rest
+(emitting `hive.policy.denied` to the client, exception fail-closed,
+running multiple policies in the configured order, applying
+mutations).
+
+---
+
+## Factory
+
+```python
+from hivemind_plugin_manager import PolicyPluginFactory
+
+cls = PolicyPluginFactory.get_class("hivemind-intent-quota-policy")
+plugin = PolicyPluginFactory.create(
+    "hivemind-intent-quota-policy",
+    config={"per_day": 100, "redis_url": "redis://..."},
+    hm_protocol=my_hm_protocol,
+)
+```
+
+Source: `hivemind_plugin_manager/__init__.py` — `PolicyPluginFactory`.
+
+`hivemind-core` uses this factory internally to assemble the configured
+chain at startup; most plugin authors will never call it directly.

--- a/docs/plugins/policy.md
+++ b/docs/plugins/policy.md
@@ -122,28 +122,40 @@ Mutations attached to a *denying* verdict are ignored.
 
 ## `Mutation`
 
-Typed actions a policy can request on a message being allowed. Adding
-new mutation kinds is the explicit, greppable way to extend what
-policies are allowed to change — there is no free-form dict-merge
-mutation by design.
+Typed actions a policy can request on a message being allowed.
+`hivemind-plugin-manager` ships only the abstract base class
+(`Mutation`) — concrete mutations are **agent-specific** and live with
+the agent plugin that knows the message shape. The OVOS agent plugin,
+for example, ships:
 
-| Class | Effect |
-|---|---|
-| `AddBlacklistedSkill(skill_id)` | Appends to `message.context["session"]["blacklisted_skills"]`. |
-| `AddBlacklistedIntent(intent_name)` | Appends to `message.context["session"]["blacklisted_intents"]`. |
-| `AddBlacklistedMessageType(msg_type)` | Appends to `message.context["session"]["blacklisted_message_types"]`. |
-| `SetSessionField(key, value)` | Sets one key in `message.context["session"]`. |
-| `SetContextField(path, value)` | Sets a nested key in `message.context` (tuple-typed path). |
-| `RewriteUtterance(text)` | Replaces `data["utterances"]` on a `recognizer_loop:utterance` message. Silent no-op on any other `msg_type`. |
+| Class | Effect | Where |
+|---|---|---|
+| `AddBlacklistedSkill(skill_id)` | Appends to `message.context["session"]["blacklisted_skills"]`. | [`hivemind_ovos_agent_plugin.policy`](https://github.com/JarbasHiveMind/hivemind-ovos-agent-plugin) |
+| `AddBlacklistedIntent(intent_name)` | Appends to `message.context["session"]["blacklisted_intents"]`. | same |
+| `AddBlacklistedMessageType(msg_type)` | Appends to `message.context["session"]["blacklisted_message_types"]`. | same |
+| `SetSessionField(key, value)` | Sets one key in `message.context["session"]`. | same |
+| `SetContextField(path, value)` | Sets a nested key in `message.context` (tuple-typed path). | same |
+| `RewriteUtterance(text)` | Replaces `data["utterances"]` on a `recognizer_loop:utterance` message. | same |
 
-All mutations are idempotent on list mutations (no duplicates) and
-robust to non-dict context/session values (they coerce). Source:
-`hivemind_plugin_manager/policy.py`.
+If you write an agent integration for something other than OVOS (e.g. a
+non-Mycroft skill engine), bring your own mutation set. The contract is
+just: subclass `Mutation`, implement `apply(message, client)`.
 
-If you need a new mutation kind, add it here in
-`hivemind-plugin-manager` rather than as a free-form mechanism in your
-plugin — the chain runner is meant to know what plugins are allowed to
-change.
+```python
+from hivemind_plugin_manager import Mutation
+
+class TagWithCorrelationID(Mutation):
+    def __init__(self, correlation_id: str):
+        self.correlation_id = correlation_id
+
+    def apply(self, message, client) -> None:
+        message.context["correlation_id"] = self.correlation_id
+```
+
+Why typed mutations and not a free-form dict-merge? So the chain runner
+(and reviewers) can see exactly what each plugin is allowed to change.
+Add new mutation kinds as named subclasses in the consumer that
+understands the field.
 
 ---
 
@@ -186,6 +198,8 @@ deployment can have multiple HiveMind clients sharing one quota.
 
 ```python
 from hivemind_plugin_manager import PolicyPlugin, Verdict
+# Mutations live with the agent plugin — import what you need from there.
+# from hivemind_ovos_agent_plugin.policy import AddBlacklistedSkill
 
 
 class IntentQuotaPolicy(PolicyPlugin):

--- a/docs/plugins/policy.md
+++ b/docs/plugins/policy.md
@@ -133,14 +133,17 @@ Typed actions a policy can request on a message being allowed.
 the agent plugin that knows the message shape. The OVOS agent plugin,
 for example, ships:
 
-| Class | Effect | Where |
-|---|---|---|
-| `AddBlacklistedSkill(skill_id)` | Appends to `message.context["session"]["blacklisted_skills"]`. | [`hivemind_ovos_agent_plugin.policy`](https://github.com/JarbasHiveMind/hivemind-ovos-agent-plugin) |
-| `AddBlacklistedIntent(intent_name)` | Appends to `message.context["session"]["blacklisted_intents"]`. | same |
-| `AddBlacklistedMessageType(msg_type)` | Appends to `message.context["session"]["blacklisted_message_types"]`. | same |
-| `SetSessionField(key, value)` | Sets one key in `message.context["session"]`. | same |
-| `SetContextField(path, value)` | Sets a nested key in `message.context` (tuple-typed path). | same |
-| `RewriteUtterance(text)` | Replaces `data["utterances"]` on a `recognizer_loop:utterance` message. | same |
+| Class | Effect |
+|---|---|
+| `AddBlacklistedSkill(skill_id)` | Appends to `message.context["session"]["blacklisted_skills"]`. |
+| `AddBlacklistedIntent(intent_name)` | Appends to `message.context["session"]["blacklisted_intents"]`. |
+| `SetSessionField(key, value)` | Sets one key in `message.context["session"]`. |
+| `SetContextField(path, value)` | Sets a nested key in `message.context` (tuple-typed path). |
+| `RewriteUtterance(text)` | Replaces `data["utterances"]` on a `recognizer_loop:utterance` message. |
+
+All of these live in
+[`hivemind_ovos_agent_plugin.policy`](https://github.com/JarbasHiveMind/hivemind-ovos-agent-plugin)
+— see that repo for current behaviour, signatures, and edge cases.
 
 If you write an agent integration for something other than OVOS (e.g. a
 non-Mycroft skill engine), bring your own mutation set. The contract is

--- a/docs/plugins/policy.md
+++ b/docs/plugins/policy.md
@@ -31,6 +31,7 @@ class PolicyPlugin(_SubProtocol):
     entry-point group and invoked in the order declared by the
     operator's policy.chain config.
     """
+    BYPASS_ADMIN: ClassVar[bool] = False
     config: Dict[str, Any] = dataclasses.field(default_factory=dict)
     hm_protocol: Optional['HiveMindListenerProtocol'] = None
 
@@ -44,6 +45,49 @@ Source: `hivemind_plugin_manager/policy.py:115`.
 `PolicyPlugin` extends `_SubProtocol`
 (`protocols.py:35`), which provides `.identity`, `.database`, and
 `.clients` properties — see [Concepts](../concepts.md#_subprotocol-base).
+
+### `BYPASS_ADMIN`
+
+A class-level boolean (`ClassVar[bool]`, default `False`) that controls
+whether the chain runner invokes this policy for **admin clients**
+(`client.is_admin == True`).
+
+| Value | Effect on admin clients |
+|---|---|
+| `False` (default) | `review` / `review_binary` / `observe` are called normally. Admins are subject to this policy. |
+| `True` | The chain runner **skips this policy entirely** for admin clients — none of the three hooks fires. Non-admin clients are unaffected. |
+
+The flag belongs on the class, not the instance — set it as a class
+attribute on your subclass:
+
+```python
+class MyOperatorOnlyAudit(PolicyPlugin):
+    BYPASS_ADMIN = False  # admins ARE audited (default, shown for clarity)
+
+    def observe(self, message, client):
+        ...
+
+class MyTenantQuota(PolicyPlugin):
+    BYPASS_ADMIN = True   # admins are exempt from quota checks
+
+    def review(self, message, client):
+        ...
+```
+
+**Use `BYPASS_ADMIN = True`** when the policy expresses a per-tenant
+or per-end-user constraint that operators legitimately need to
+sidestep (rate limits, content filters, A/B-test gating, sensitive-
+intent confirmation prompts).
+
+**Keep `BYPASS_ADMIN = False`** when the policy expresses an
+ecosystem-wide invariant that admins should also obey (allowed-type
+admission, audit logging, security scrubbing). The default is
+deliberately conservative.
+
+Enforcement happens in the chain runner (`hivemind-core`), not inside
+the policy itself — your subclass doesn't need to check
+`client.is_admin`. Just set the class attribute and let the runner
+handle the skip.
 
 ---
 

--- a/docs/plugins/policy.md
+++ b/docs/plugins/policy.md
@@ -31,7 +31,6 @@ class PolicyPlugin(_SubProtocol):
     entry-point group and invoked in the order declared by the
     operator's policy.chain config.
     """
-    BYPASS_ADMIN: ClassVar[bool] = False
     config: Dict[str, Any] = dataclasses.field(default_factory=dict)
     hm_protocol: Optional['HiveMindListenerProtocol'] = None
 
@@ -46,48 +45,21 @@ Source: `hivemind_plugin_manager/policy.py:115`.
 (`protocols.py:35`), which provides `.identity`, `.database`, and
 `.clients` properties — see [Concepts](../concepts.md#_subprotocol-base).
 
-### `BYPASS_ADMIN`
+### `client.is_admin`
 
-A class-level boolean (`ClassVar[bool]`, default `False`) that controls
-whether the chain runner invokes this policy for **admin clients**
-(`client.is_admin == True`).
+`Client.is_admin` is **informational only**. The chain runner does not
+give it any special treatment — every policy is invoked for every
+client, admin or not.
 
-| Value | Effect on admin clients |
-|---|---|
-| `False` (default) | `review` / `review_binary` / `observe` are called normally. Admins are subject to this policy. |
-| `True` | The chain runner **skips this policy entirely** for admin clients — none of the three hooks fires. Non-admin clients are unaffected. |
+Policies that care about admin status check `client.is_admin`
+themselves inside `review` and decide what to do with it. Concrete
+example (the only one in the first-party ecosystem):
+`OVOSAgentPolicy` refuses messages with `session_id == "default"` for
+non-admins but lets admins through.
 
-The flag belongs on the class, not the instance — set it as a class
-attribute on your subclass:
-
-```python
-class MyOperatorOnlyAudit(PolicyPlugin):
-    BYPASS_ADMIN = False  # admins ARE audited (default, shown for clarity)
-
-    def observe(self, message, client):
-        ...
-
-class MyTenantQuota(PolicyPlugin):
-    BYPASS_ADMIN = True   # admins are exempt from quota checks
-
-    def review(self, message, client):
-        ...
-```
-
-**Use `BYPASS_ADMIN = True`** when the policy expresses a per-tenant
-or per-end-user constraint that operators legitimately need to
-sidestep (rate limits, content filters, A/B-test gating, sensitive-
-intent confirmation prompts).
-
-**Keep `BYPASS_ADMIN = False`** when the policy expresses an
-ecosystem-wide invariant that admins should also obey (allowed-type
-admission, audit logging, security scrubbing). The default is
-deliberately conservative.
-
-Enforcement happens in the chain runner (`hivemind-core`), not inside
-the policy itself — your subclass doesn't need to check
-`client.is_admin`. Just set the class attribute and let the runner
-handle the skip.
+There is no class-level `BYPASS_ADMIN` switch and no runner-level
+admin handling. If your policy should be a no-op for admins, branch
+on `client.is_admin` at the top of `review`.
 
 ---
 

--- a/docs/plugins/policy.md
+++ b/docs/plugins/policy.md
@@ -39,7 +39,7 @@ class PolicyPlugin(_SubProtocol):
     def observe(self, message, client) -> None: ...
 ```
 
-Source: `hivemind_plugin_manager/policy.py`.
+Source: `hivemind_plugin_manager/policy.py:115`.
 
 `PolicyPlugin` extends `_SubProtocol`
 (`protocols.py:35`), which provides `.identity`, `.database`, and
@@ -75,6 +75,8 @@ agent protocol — out of scope for this contract.
 
 The return value of `review()` and `review_binary()`.
 
+Source: `hivemind_plugin_manager/policy.py:73`
+
 ```python
 @dataclass
 class Verdict:
@@ -96,7 +98,8 @@ A verdict is either denying or allowing-with-mutations:
 # Allow, no changes
 return Verdict.allow()
 
-# Allow, with mutations
+# Allow, with mutations (concrete Mutation subclasses come from the agent plugin)
+# from hivemind_ovos_agent_plugin.policy import AddBlacklistedSkill, SetSessionField
 return Verdict.allow(
     AddBlacklistedSkill("adult.skill"),
     SetSessionField("filter_level", "family"),
@@ -121,6 +124,8 @@ Mutations attached to a *denying* verdict are ignored.
 ---
 
 ## `Mutation`
+
+Source: `hivemind_plugin_manager/policy.py:47`
 
 Typed actions a policy can request on a message being allowed.
 `hivemind-plugin-manager` ships only the abstract base class

--- a/hivemind_plugin_manager/__init__.py
+++ b/hivemind_plugin_manager/__init__.py
@@ -4,7 +4,15 @@ from typing import Optional, Dict, Any, Union, Type
 from ovos_utils.log import LOG
 from importlib.metadata import entry_points
 from hivemind_plugin_manager.database import AbstractDB, AbstractRemoteDB
-from hivemind_plugin_manager.protocols import AgentProtocol, BinaryDataHandlerProtocol, NetworkProtocol
+from hivemind_plugin_manager.policy import (AddBlacklistedIntent,
+                                            AddBlacklistedMessageType,
+                                            AddBlacklistedSkill, Mutation,
+                                            PolicyPlugin, RewriteUtterance,
+                                            SetContextField, SetSessionField,
+                                            Verdict)
+from hivemind_plugin_manager.protocols import (AgentProtocol,
+                                               BinaryDataHandlerProtocol,
+                                               NetworkProtocol)
 
 
 class HiveMindPluginTypes(str, enum.Enum):
@@ -12,6 +20,7 @@ class HiveMindPluginTypes(str, enum.Enum):
     NETWORK_PROTOCOL = "hivemind.network.protocol"
     AGENT_PROTOCOL = "hivemind.agent.protocol"
     BINARY_PROTOCOL = "hivemind.binary.protocol"
+    POLICY = "hivemind.policy"
 
 
 class DatabaseFactory:
@@ -87,6 +96,28 @@ class BinaryDataHandlerProtocolFactory:
         config = config or {}
         plugin = cls.get_class(plugin_name)
         return plugin(config=config, hm_protocol=hm_protocol, agent_protocol=agent_protocol)
+
+
+class PolicyPluginFactory:
+    """Discover and instantiate policy plugins registered under
+    ``hivemind.policy``. Consumed by ``hivemind-core``'s chain runner
+    when assembling the configured ``policy.chain``.
+    """
+
+    @classmethod
+    def get_class(cls, plugin_name: str) -> Type[PolicyPlugin]:
+        plugins = find_plugins(HiveMindPluginTypes.POLICY)
+        if plugin_name not in plugins:
+            raise KeyError(f"'{plugin_name}' not found. Available plugins: {list(plugins.keys())}")
+        return plugins[plugin_name]
+
+    @classmethod
+    def create(cls, plugin_name: str,
+               config: Optional[Dict[str, Any]] = None,
+               hm_protocol: Optional['HiveMindListenerProtocol'] = None) -> PolicyPlugin:
+        config = config or {}
+        plugin = cls.get_class(plugin_name)
+        return plugin(config=config, hm_protocol=hm_protocol)
 
 
 def find_plugins(plug_type: HiveMindPluginTypes = None) -> dict:

--- a/hivemind_plugin_manager/__init__.py
+++ b/hivemind_plugin_manager/__init__.py
@@ -9,6 +9,28 @@ from hivemind_plugin_manager.protocols import (AgentProtocol,
                                                BinaryDataHandlerProtocol,
                                                NetworkProtocol)
 
+# Public re-exports — ``Mutation`` and ``Verdict`` are only referenced
+# via this module by downstream plugin authors, so the imports above
+# look unused to a flake8/ruff F401 pass. Listing them here marks them
+# as the package's public surface and silences the warning.
+__all__ = [
+    "AbstractDB",
+    "AbstractRemoteDB",
+    "AgentProtocol",
+    "AgentProtocolFactory",
+    "BinaryDataHandlerProtocol",
+    "BinaryDataHandlerProtocolFactory",
+    "DatabaseFactory",
+    "HiveMindPluginTypes",
+    "Mutation",
+    "NetworkProtocol",
+    "NetworkProtocolFactory",
+    "PolicyPlugin",
+    "PolicyPluginFactory",
+    "Verdict",
+    "find_plugins",
+]
+
 
 class HiveMindPluginTypes(str, enum.Enum):
     DATABASE = "hivemind.database"

--- a/hivemind_plugin_manager/__init__.py
+++ b/hivemind_plugin_manager/__init__.py
@@ -4,12 +4,7 @@ from typing import Optional, Dict, Any, Union, Type
 from ovos_utils.log import LOG
 from importlib.metadata import entry_points
 from hivemind_plugin_manager.database import AbstractDB, AbstractRemoteDB
-from hivemind_plugin_manager.policy import (AddBlacklistedIntent,
-                                            AddBlacklistedMessageType,
-                                            AddBlacklistedSkill, Mutation,
-                                            PolicyPlugin, RewriteUtterance,
-                                            SetContextField, SetSessionField,
-                                            Verdict)
+from hivemind_plugin_manager.policy import Mutation, PolicyPlugin, Verdict
 from hivemind_plugin_manager.protocols import (AgentProtocol,
                                                BinaryDataHandlerProtocol,
                                                NetworkProtocol)

--- a/hivemind_plugin_manager/__init__.py
+++ b/hivemind_plugin_manager/__init__.py
@@ -5,7 +5,7 @@ from ovos_utils.log import LOG
 from importlib.metadata import entry_points
 from hivemind_plugin_manager.database import AbstractDB, AbstractRemoteDB
 from hivemind_plugin_manager.policy import (DenyCodes, Mutation, PolicyPlugin,
-                                             RESOLVED_CLIENT_CTX_KEY, Verdict)
+                                             Verdict)
 from hivemind_plugin_manager.protocols import (AgentProtocol,
                                                BinaryDataHandlerProtocol,
                                                NetworkProtocol)
@@ -25,7 +25,6 @@ __all__ = [
     "DenyCodes",
     "HiveMindPluginTypes",
     "Mutation",
-    "RESOLVED_CLIENT_CTX_KEY",
     "NetworkProtocol",
     "NetworkProtocolFactory",
     "PolicyPlugin",

--- a/hivemind_plugin_manager/__init__.py
+++ b/hivemind_plugin_manager/__init__.py
@@ -4,7 +4,8 @@ from typing import Optional, Dict, Any, Union, Type
 from ovos_utils.log import LOG
 from importlib.metadata import entry_points
 from hivemind_plugin_manager.database import AbstractDB, AbstractRemoteDB
-from hivemind_plugin_manager.policy import Mutation, PolicyPlugin, Verdict
+from hivemind_plugin_manager.policy import (DenyCodes, Mutation, PolicyPlugin,
+                                             RESOLVED_CLIENT_CTX_KEY, Verdict)
 from hivemind_plugin_manager.protocols import (AgentProtocol,
                                                BinaryDataHandlerProtocol,
                                                NetworkProtocol)
@@ -21,8 +22,10 @@ __all__ = [
     "BinaryDataHandlerProtocol",
     "BinaryDataHandlerProtocolFactory",
     "DatabaseFactory",
+    "DenyCodes",
     "HiveMindPluginTypes",
     "Mutation",
+    "RESOLVED_CLIENT_CTX_KEY",
     "NetworkProtocol",
     "NetworkProtocolFactory",
     "PolicyPlugin",

--- a/hivemind_plugin_manager/database.py
+++ b/hivemind_plugin_manager/database.py
@@ -170,12 +170,15 @@ class Client:
             if legacy_key in client_data:
                 val = client_data.pop(legacy_key)
                 if val:
+                    # stacklevel=3 so the warning points past
+                    # deserialize() and cast2client() at the actual
+                    # user / DB-backend caller.
                     warnings.warn(
                         f"Client.{legacy_key} top-level field is deprecated; "
                         f"migrating into Client.metadata['{legacy_key}']. "
                         "Use Client.metadata directly or configure the "
                         "OVOSAgentPolicy plugin.",
-                        DeprecationWarning, stacklevel=2,
+                        DeprecationWarning, stacklevel=3,
                     )
                     metadata.setdefault(legacy_key, list(val))
 

--- a/hivemind_plugin_manager/database.py
+++ b/hivemind_plugin_manager/database.py
@@ -115,13 +115,11 @@ class Client:
         else:
             self.metadata.pop("intent_blacklist", None)
 
-    # message_blacklist is gone — the field was introduced 2024-12-20
-    # in commit 94a2141 alongside the rename/multidb refactor and
-    # contradicted the deny-by-default whitelist model. No property
-    # shim and no carry-forward (deserialize strips the top-level key
-    # silently, the kwarg path discards the value with a
-    # DeprecationWarning). The kwarg is still ACCEPTED to keep
-    # partial-upgrade safety with already-shipped backends.
+    # message_blacklist is not part of the data model. No property
+    # shim and no metadata carry-forward; deserialize strips the
+    # top-level key silently, the kwarg path discards the value with
+    # a DeprecationWarning but the kwarg itself is accepted so
+    # backends passing it positionally don't crash.
 
     def serialize(self) -> str:
         """
@@ -170,13 +168,8 @@ class Client:
                     )
                     metadata.setdefault(legacy_key, list(val))
 
-        # message_blacklist was a design mistake from the 2024-12-20
-        # rename/multidb refactor — it contradicted the deny-by-default
-        # whitelist model and never functioned as a real gate. Strip it
-        # silently from on-disk records so legacy DBs keep loading.
-        # Operators who configured it can recover their list from the
-        # backend's pre-migration storage if needed; no automatic
-        # carry-forward.
+        # message_blacklist is not part of the data model; drop the
+        # key without carry-forward so on-disk records keep loading.
         client_data.pop("message_blacklist", None)
 
         known = {f.name for f in fields(Client)}
@@ -251,8 +244,8 @@ class Client:
 # (skill_blacklist, intent_blacklist) are accepted and auto-migrated
 # into metadata. Done as a post-class assignment because @property
 # attributes with the same name conflict with both dataclass field
-# annotations and InitVar pseudo-fields. ``message_blacklist`` is also
-# accepted-and-discarded for partial-upgrade safety — see comment in
+# annotations and InitVar pseudo-fields. ``message_blacklist`` is
+# accepted-and-discarded — see comment in
 # ``_client_init_with_legacy_kwargs``.
 _client_dataclass_init = Client.__init__
 
@@ -260,17 +253,10 @@ _client_dataclass_init = Client.__init__
 def _client_init_with_legacy_kwargs(self, *args, skill_blacklist=None,
                                      intent_blacklist=None,
                                      message_blacklist=None, **kwargs):
-    # message_blacklist is REMOVED from the data model — the field was
-    # introduced 2024-12-20 (commit 94a2141) alongside the legitimate
-    # ACL work but contradicted the deny-by-default whitelist model and
-    # never functioned as a real gate.
-    #
-    # The kwarg is still accepted (rather than raising TypeError) so
-    # already-shipped backends — most notably the pre-release SQLite
-    # plugin's _row_to_client, which passes ``message_blacklist=`` as
-    # a positional from each row — don't crash when users upgrade HPM
-    # alone. The value is discarded with a one-shot DeprecationWarning
-    # per call: no metadata carry-forward, no silent persistence.
+    # ``message_blacklist`` is accepted-and-discarded with a
+    # DeprecationWarning. The kwarg surface is preserved so backends
+    # passing it positionally still construct successfully; the value
+    # is dropped (no metadata carry-forward, no persistence).
     _client_dataclass_init(self, *args, **kwargs)
     for key, val in (("skill_blacklist", skill_blacklist),
                      ("intent_blacklist", intent_blacklist)):

--- a/hivemind_plugin_manager/database.py
+++ b/hivemind_plugin_manager/database.py
@@ -69,16 +69,12 @@ class Client:
             raise ValueError("is_admin should be a boolean")
         if not isinstance(self.metadata, dict):
             self.metadata = {}
-        self.allowed_types = self.allowed_types or ["recognizer_loop:utterance",
-                                                    "recognizer_loop:record_begin",
-                                                    "recognizer_loop:record_end",
-                                                    "recognizer_loop:audio_output_start",
-                                                    "recognizer_loop:audio_output_end",
-                                                    'recognizer_loop:b64_transcribe',
-                                                    'speak:b64_audio',
-                                                    "ovos.common_play.SEI.get.response"]
-        if "recognizer_loop:utterance" not in self.allowed_types:
-            self.allowed_types.append("recognizer_loop:utterance")
+        # `allowed_types` is the canonical admission whitelist (enforced
+        # by ClientACLPolicy in hivemind-core). Deny-by-default: an empty
+        # list means the client cannot inject any message type. No
+        # default-substitution and no auto-append — operators grant
+        # access explicitly via `hivemind-core allow-msg <type> <id>`
+        # or by passing `allowed_types=[...]` on construction.
 
     # ------------------------------------------------------------------
     # Deprecated property shims — read/write to metadata transparently.
@@ -119,21 +115,13 @@ class Client:
         else:
             self.metadata.pop("intent_blacklist", None)
 
-    @property
-    def message_blacklist(self) -> List[str]:
-        return list(self.metadata.get("message_blacklist") or [])
-
-    @message_blacklist.setter
-    def message_blacklist(self, value):
-        warnings.warn(
-            "Client.message_blacklist setter is deprecated; write to "
-            "Client.metadata['message_blacklist'] instead.",
-            DeprecationWarning, stacklevel=2,
-        )
-        if value:
-            self.metadata["message_blacklist"] = list(value)
-        else:
-            self.metadata.pop("message_blacklist", None)
+    # message_blacklist property removed in v0.6 — hivemind-core is
+    # whitelist-only (deny by default) and has no consumer for an
+    # outbound message blacklist. Data passed as the legacy
+    # ``message_blacklist`` kwarg or top-level key in serialized records
+    # is still preserved in metadata for back-compat / third-party
+    # plugins that may consult it, but Client no longer exposes a
+    # top-level attribute for reading it.
 
     def serialize(self) -> str:
         """

--- a/hivemind_plugin_manager/database.py
+++ b/hivemind_plugin_manager/database.py
@@ -115,13 +115,12 @@ class Client:
         else:
             self.metadata.pop("intent_blacklist", None)
 
-    # message_blacklist property removed in v0.6 — hivemind-core is
-    # whitelist-only (deny by default) and has no consumer for an
-    # outbound message blacklist. Data passed as the legacy
-    # ``message_blacklist`` kwarg or top-level key in serialized records
-    # is still preserved in metadata for back-compat / third-party
-    # plugins that may consult it, but Client no longer exposes a
-    # top-level attribute for reading it.
+    # message_blacklist is gone — the field was introduced 2024-12-20
+    # in commit 94a2141 alongside the rename/multidb refactor and
+    # contradicted the deny-by-default whitelist model. No property
+    # shim, no kwarg, no deserialize-side carry-forward: on-disk
+    # records have the key stripped silently, callers passing it as a
+    # constructor kwarg get TypeError.
 
     def serialize(self) -> str:
         """
@@ -154,7 +153,7 @@ class Client:
         # existing on-disk JSON DBs keep loading. Emits a one-time
         # DeprecationWarning per legacy key seen. Don't clobber values
         # already in metadata.
-        for legacy_key in ("skill_blacklist", "intent_blacklist", "message_blacklist"):
+        for legacy_key in ("skill_blacklist", "intent_blacklist"):
             if legacy_key in client_data:
                 val = client_data.pop(legacy_key)
                 if val:
@@ -169,6 +168,15 @@ class Client:
                         DeprecationWarning, stacklevel=3,
                     )
                     metadata.setdefault(legacy_key, list(val))
+
+        # message_blacklist was a design mistake from the 2024-12-20
+        # rename/multidb refactor — it contradicted the deny-by-default
+        # whitelist model and never functioned as a real gate. Strip it
+        # silently from on-disk records so legacy DBs keep loading.
+        # Operators who configured it can recover their list from the
+        # backend's pre-migration storage if needed; no automatic
+        # carry-forward.
+        client_data.pop("message_blacklist", None)
 
         known = {f.name for f in fields(Client)}
         extras = {k: client_data.pop(k) for k in list(client_data) if k not in known}
@@ -239,20 +247,24 @@ class Client:
 
 
 # Wrap the dataclass-generated __init__ so legacy constructor kwargs
-# (skill_blacklist, intent_blacklist, message_blacklist) are accepted
-# and auto-migrated into metadata. Done as a post-class assignment
-# because @property attributes with the same name conflict with both
-# dataclass field annotations and InitVar pseudo-fields.
+# (skill_blacklist, intent_blacklist) are accepted and auto-migrated
+# into metadata. Done as a post-class assignment because @property
+# attributes with the same name conflict with both dataclass field
+# annotations and InitVar pseudo-fields. ``message_blacklist`` is NOT
+# accepted — see comment in ``_client_init_with_legacy_kwargs``.
 _client_dataclass_init = Client.__init__
 
 
 def _client_init_with_legacy_kwargs(self, *args, skill_blacklist=None,
-                                     intent_blacklist=None,
-                                     message_blacklist=None, **kwargs):
+                                     intent_blacklist=None, **kwargs):
+    # message_blacklist is intentionally NOT accepted: the field was
+    # introduced in 2024-12-20 alongside the legitimate ACL work but
+    # contradicted the deny-by-default whitelist model and was never a
+    # supported gating mechanism. Removed outright — callers passing
+    # the kwarg get a TypeError, which is the desired signal.
     _client_dataclass_init(self, *args, **kwargs)
     for key, val in (("skill_blacklist", skill_blacklist),
-                     ("intent_blacklist", intent_blacklist),
-                     ("message_blacklist", message_blacklist)):
+                     ("intent_blacklist", intent_blacklist)):
         if val:
             warnings.warn(
                 f"Client.{key} kwarg is deprecated; auto-migrating into "

--- a/hivemind_plugin_manager/database.py
+++ b/hivemind_plugin_manager/database.py
@@ -118,9 +118,10 @@ class Client:
     # message_blacklist is gone — the field was introduced 2024-12-20
     # in commit 94a2141 alongside the rename/multidb refactor and
     # contradicted the deny-by-default whitelist model. No property
-    # shim, no kwarg, no deserialize-side carry-forward: on-disk
-    # records have the key stripped silently, callers passing it as a
-    # constructor kwarg get TypeError.
+    # shim and no carry-forward (deserialize strips the top-level key
+    # silently, the kwarg path discards the value with a
+    # DeprecationWarning). The kwarg is still ACCEPTED to keep
+    # partial-upgrade safety with already-shipped backends.
 
     def serialize(self) -> str:
         """
@@ -250,18 +251,26 @@ class Client:
 # (skill_blacklist, intent_blacklist) are accepted and auto-migrated
 # into metadata. Done as a post-class assignment because @property
 # attributes with the same name conflict with both dataclass field
-# annotations and InitVar pseudo-fields. ``message_blacklist`` is NOT
-# accepted — see comment in ``_client_init_with_legacy_kwargs``.
+# annotations and InitVar pseudo-fields. ``message_blacklist`` is also
+# accepted-and-discarded for partial-upgrade safety — see comment in
+# ``_client_init_with_legacy_kwargs``.
 _client_dataclass_init = Client.__init__
 
 
 def _client_init_with_legacy_kwargs(self, *args, skill_blacklist=None,
-                                     intent_blacklist=None, **kwargs):
-    # message_blacklist is intentionally NOT accepted: the field was
-    # introduced in 2024-12-20 alongside the legitimate ACL work but
-    # contradicted the deny-by-default whitelist model and was never a
-    # supported gating mechanism. Removed outright — callers passing
-    # the kwarg get a TypeError, which is the desired signal.
+                                     intent_blacklist=None,
+                                     message_blacklist=None, **kwargs):
+    # message_blacklist is REMOVED from the data model — the field was
+    # introduced 2024-12-20 (commit 94a2141) alongside the legitimate
+    # ACL work but contradicted the deny-by-default whitelist model and
+    # never functioned as a real gate.
+    #
+    # The kwarg is still accepted (rather than raising TypeError) so
+    # already-shipped backends — most notably the pre-release SQLite
+    # plugin's _row_to_client, which passes ``message_blacklist=`` as
+    # a positional from each row — don't crash when users upgrade HPM
+    # alone. The value is discarded with a one-shot DeprecationWarning
+    # per call: no metadata carry-forward, no silent persistence.
     _client_dataclass_init(self, *args, **kwargs)
     for key, val in (("skill_blacklist", skill_blacklist),
                      ("intent_blacklist", intent_blacklist)):
@@ -273,6 +282,15 @@ def _client_init_with_legacy_kwargs(self, *args, skill_blacklist=None,
                 DeprecationWarning, stacklevel=2,
             )
             self.metadata.setdefault(key, list(val))
+    if message_blacklist:
+        warnings.warn(
+            "Client.message_blacklist is REMOVED — the value passed "
+            "via this kwarg is being discarded. The field contradicted "
+            "the deny-by-default whitelist model and was never a real "
+            "admission gate. Stop passing this kwarg; it will be "
+            "rejected entirely in a future release.",
+            DeprecationWarning, stacklevel=2,
+        )
 
 
 Client.__init__ = _client_init_with_legacy_kwargs

--- a/hivemind_plugin_manager/database.py
+++ b/hivemind_plugin_manager/database.py
@@ -1,5 +1,6 @@
 import abc
 import json
+import warnings
 from dataclasses import dataclass, field, fields
 from typing import List, Dict, Union, Any, Optional, Iterable
 
@@ -39,9 +40,11 @@ class Client:
     description: str = ""
     is_admin: bool = False
     last_seen: float = -1
-    intent_blacklist: List[str] = field(default_factory=list)
-    skill_blacklist: List[str] = field(default_factory=list)
-    message_blacklist: List[str] = field(default_factory=list)
+    # admission whitelist of OVOS bus message types the client may inject.
+    # Empty list = deny everything (hivemind-core's policy is whitelist-only;
+    # there is no message blacklist). Agent-specific blacklists (skill,
+    # intent, etc.) live in plugin config or `metadata`, not on the
+    # Client row directly. See HiveMind-core#85.
     allowed_types: List[str] = field(default_factory=list)
     crypto_key: Optional[str] = None
     password: Optional[str] = None
@@ -51,8 +54,14 @@ class Client:
     metadata: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
-        """
-        Initializes the allowed types for the Client instance if not provided.
+        """Validate the Client.
+
+        OVOS-specific per-client ACL lists (skill / intent / message
+        blacklists) live in :attr:`metadata` now — see the property
+        shims below. Legacy callers that pass them as constructor
+        kwargs go through :meth:`deserialize` /
+        :meth:`ClientDatabase.add_client`, both of which detect and
+        migrate them. See HiveMind-core#85.
         """
         if not isinstance(self.client_id, int):
             raise ValueError("client_id should be an integer")
@@ -70,6 +79,61 @@ class Client:
                                                     "ovos.common_play.SEI.get.response"]
         if "recognizer_loop:utterance" not in self.allowed_types:
             self.allowed_types.append("recognizer_loop:utterance")
+
+    # ------------------------------------------------------------------
+    # Deprecated property shims — read/write to metadata transparently.
+    # Older callers (CLI list-clients, OVOSAgentPolicy, third-party
+    # scripts) that use ``client.skill_blacklist`` keep working. New
+    # code should use ``client.metadata["skill_blacklist"]`` directly.
+    # ------------------------------------------------------------------
+
+    @property
+    def skill_blacklist(self) -> List[str]:
+        return list(self.metadata.get("skill_blacklist") or [])
+
+    @skill_blacklist.setter
+    def skill_blacklist(self, value):
+        warnings.warn(
+            "Client.skill_blacklist setter is deprecated; write to "
+            "Client.metadata['skill_blacklist'] instead.",
+            DeprecationWarning, stacklevel=2,
+        )
+        if value:
+            self.metadata["skill_blacklist"] = list(value)
+        else:
+            self.metadata.pop("skill_blacklist", None)
+
+    @property
+    def intent_blacklist(self) -> List[str]:
+        return list(self.metadata.get("intent_blacklist") or [])
+
+    @intent_blacklist.setter
+    def intent_blacklist(self, value):
+        warnings.warn(
+            "Client.intent_blacklist setter is deprecated; write to "
+            "Client.metadata['intent_blacklist'] instead.",
+            DeprecationWarning, stacklevel=2,
+        )
+        if value:
+            self.metadata["intent_blacklist"] = list(value)
+        else:
+            self.metadata.pop("intent_blacklist", None)
+
+    @property
+    def message_blacklist(self) -> List[str]:
+        return list(self.metadata.get("message_blacklist") or [])
+
+    @message_blacklist.setter
+    def message_blacklist(self, value):
+        warnings.warn(
+            "Client.message_blacklist setter is deprecated; write to "
+            "Client.metadata['message_blacklist'] instead.",
+            DeprecationWarning, stacklevel=2,
+        )
+        if value:
+            self.metadata["message_blacklist"] = list(value)
+        else:
+            self.metadata.pop("message_blacklist", None)
 
     def serialize(self) -> str:
         """
@@ -97,6 +161,23 @@ class Client:
             client_data = dict(client_data)  # don't mutate caller's dict
 
         metadata = client_data.pop("metadata", None) or {}
+
+        # Auto-migrate legacy top-level blacklist fields into metadata so
+        # existing on-disk JSON DBs keep loading. Emits a one-time
+        # DeprecationWarning per legacy key seen. Don't clobber values
+        # already in metadata.
+        for legacy_key in ("skill_blacklist", "intent_blacklist", "message_blacklist"):
+            if legacy_key in client_data:
+                val = client_data.pop(legacy_key)
+                if val:
+                    warnings.warn(
+                        f"Client.{legacy_key} top-level field is deprecated; "
+                        f"migrating into Client.metadata['{legacy_key}']. "
+                        "Use Client.metadata directly or configure the "
+                        "OVOSAgentPolicy plugin.",
+                        DeprecationWarning, stacklevel=2,
+                    )
+                    metadata.setdefault(legacy_key, list(val))
 
         known = {f.name for f in fields(Client)}
         extras = {k: client_data.pop(k) for k in list(client_data) if k not in known}
@@ -164,6 +245,34 @@ class Client:
             A string representing the client.
         """
         return self.serialize()
+
+
+# Wrap the dataclass-generated __init__ so legacy constructor kwargs
+# (skill_blacklist, intent_blacklist, message_blacklist) are accepted
+# and auto-migrated into metadata. Done as a post-class assignment
+# because @property attributes with the same name conflict with both
+# dataclass field annotations and InitVar pseudo-fields.
+_client_dataclass_init = Client.__init__
+
+
+def _client_init_with_legacy_kwargs(self, *args, skill_blacklist=None,
+                                     intent_blacklist=None,
+                                     message_blacklist=None, **kwargs):
+    _client_dataclass_init(self, *args, **kwargs)
+    for key, val in (("skill_blacklist", skill_blacklist),
+                     ("intent_blacklist", intent_blacklist),
+                     ("message_blacklist", message_blacklist)):
+        if val:
+            warnings.warn(
+                f"Client.{key} kwarg is deprecated; auto-migrating into "
+                f"Client.metadata['{key}']. Use Client.metadata directly "
+                "or configure the OVOSAgentPolicy plugin.",
+                DeprecationWarning, stacklevel=2,
+            )
+            self.metadata.setdefault(key, list(val))
+
+
+Client.__init__ = _client_init_with_legacy_kwargs
 
 
 @dataclass

--- a/hivemind_plugin_manager/database.py
+++ b/hivemind_plugin_manager/database.py
@@ -2,7 +2,7 @@ import abc
 import json
 import warnings
 from dataclasses import dataclass, field, fields
-from typing import List, Dict, Union, Any, Optional, Iterable
+from typing import List, Dict, Union, Any, ClassVar, Optional, Iterable
 
 
 ClientDict = Dict[str, Any]
@@ -364,6 +364,28 @@ class AbstractDB(abc.ABC):
     def sync(self):
         """update db from disk if needed"""
         pass
+
+    # Schema version of the in-memory ``Client`` shape this code expects.
+    # Bumped when the on-disk representation changes in a way that
+    # warrants a backend migration. Backends compare this against their
+    # persisted version (e.g. SQLite ``PRAGMA user_version``, a sentinel
+    # key in JSON/Redis) and call ``migrate()`` once when stored < this.
+    SCHEMA_VERSION: ClassVar[int] = 2
+
+    def migrate(self, from_version: int) -> None:
+        """Backend-specific schema/data migration hook.
+
+        Called once during backend init when the persisted schema version
+        is lower than ``SCHEMA_VERSION``. Default is a no-op so existing
+        third-party backends keep working without modification; backends
+        that store legacy fields (``skill_blacklist``, ``intent_blacklist``,
+        ``message_blacklist`` as top-level columns/keys) should override
+        this to move them into ``Client.metadata`` and drop the legacy
+        storage. Implementations MUST be idempotent and crash-safe — a
+        partial migration on retry must produce the same final state.
+
+        v1 -> v2: legacy OVOS blacklist fields migrated into metadata.
+        """
 
     def commit(self) -> bool:
         """

--- a/hivemind_plugin_manager/database.py
+++ b/hivemind_plugin_manager/database.py
@@ -70,7 +70,7 @@ class Client:
         if not isinstance(self.metadata, dict):
             self.metadata = {}
         # `allowed_types` is the canonical admission whitelist (enforced
-        # by ClientACLPolicy in hivemind-core). Deny-by-default: an empty
+        # by MessageTypeACLPolicy in hivemind-core). Deny-by-default: an empty
         # list means the client cannot inject any message type. No
         # default-substitution and no auto-append — operators grant
         # access explicitly via `hivemind-core allow-msg <type> <id>`

--- a/hivemind_plugin_manager/database.py
+++ b/hivemind_plugin_manager/database.py
@@ -381,6 +381,48 @@ class AbstractDB(abc.ABC):
         """update db from disk if needed"""
         pass
 
+    def refresh(self, client_id: int) -> Optional['Client']:
+        """Refresh a single client record from the backing store.
+
+        Backends override for targeted invalidation; the default just
+        re-reads via :meth:`get_client_by_id`. Implementations MUST NOT
+        trigger a global keyspace scan or index rebuild — this is called
+        on the hot admission path, once per inbound message.
+        """
+        return self.get_client_by_id(client_id)
+
+    def get_client_by_id(self, client_id: int) -> Optional['Client']:
+        """Return the client with the given ``client_id`` or ``None``.
+
+        Default implementation uses :meth:`search_by_value` so backends
+        get a working lookup for free. Backends with a faster path
+        (direct key get, indexed lookup) should override.
+        """
+        if client_id is None:
+            return None
+        try:
+            matches = self.search_by_value("client_id", int(client_id))
+        except (TypeError, ValueError):
+            return None
+        return matches[0] if matches else None
+
+    def _check_forward_compat(self, stored_version: int) -> None:
+        """Raise ``RuntimeError`` if the stored schema version is newer
+        than this backend supports.
+
+        Backends call this from ``_maybe_migrate`` immediately after
+        reading their persisted version sentinel, before the
+        ``stored < target`` migration branch. Forward-incompatible DBs
+        must fail loudly instead of being silently downgraded.
+        """
+        target = getattr(type(self), "SCHEMA_VERSION", 1)
+        if stored_version > target:
+            raise RuntimeError(
+                f"Database schema version {stored_version} is newer than "
+                f"this backend supports (target={target}). Upgrade "
+                f"hivemind-plugin-manager / the backend plugin."
+            )
+
     # Schema version of the in-memory ``Client`` shape this code expects.
     # Bumped when the on-disk representation changes in a way that
     # warrants a backend migration. Backends compare this against their

--- a/hivemind_plugin_manager/database.py
+++ b/hivemind_plugin_manager/database.py
@@ -146,7 +146,9 @@ class Client:
         else:
             client_data = dict(client_data)  # don't mutate caller's dict
 
-        metadata = client_data.pop("metadata", None) or {}
+        metadata = client_data.pop("metadata", None)
+        if not isinstance(metadata, dict):
+            metadata = {}
 
         # Auto-migrate legacy top-level blacklist fields into metadata so
         # existing on-disk JSON DBs keep loading. Emits a one-time

--- a/hivemind_plugin_manager/policy.py
+++ b/hivemind_plugin_manager/policy.py
@@ -4,9 +4,12 @@ A **policy plugin** is HiveMind's admission-control point: it sees every
 Mycroft ``Message`` (and every binary payload) about to be forwarded to the
 agent bus, and can allow it, deny it, or mutate it.
 
-This module ships only the *primitives* — the plugin base class and the
-typed data the chain runner consumes. The actual chain runner lives in
-``hivemind-core`` and is the consumer of everything declared here.
+This module ships only the *primitives* — the plugin base class, the
+typed verdict, and the :class:`Mutation` abstract base class. Concrete
+mutation kinds are agent-specific and live with their consumer (e.g.
+the OVOS agent plugin ships ``AddBlacklistedSkill``, ``AddBlacklistedIntent``,
+``RewriteUtterance``, etc., since those manipulate OVOS session/message
+shape). New agent integrations bring their own mutation set.
 
 Three concepts:
 
@@ -15,10 +18,9 @@ Three concepts:
 - :class:`Verdict` — what ``review()`` returns. Either allow (optionally
   carrying mutations) or deny (with a code, reason, and structured data
   for the client-side denial message).
-- :class:`Mutation` — typed actions a policy can request on a message that
-  is being allowed. Stdlib subclasses cover the common cases; new mutation
-  kinds are added here so the set is greppable and the chain runner stays
-  honest about what plugins are allowed to change.
+- :class:`Mutation` — abstract base for typed actions a policy can request
+  on a message that is being allowed. Concrete subclasses live with the
+  agent plugin that knows the message shape.
 
 Design references:
 
@@ -33,24 +35,22 @@ from __future__ import annotations
 import abc
 import dataclasses
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple
-
-from ovos_utils.log import LOG
+from typing import Any, Dict, List, Optional
 
 from hivemind_plugin_manager.protocols import _SubProtocol
 
 
 # ---------------------------------------------------------------------------
-# Mutations
+# Mutation ABC
 # ---------------------------------------------------------------------------
 
 class Mutation(abc.ABC):
     """A typed action a policy can request on a message being allowed.
 
+    Concrete subclasses are agent-specific and live with the consumer
+    (e.g. ``hivemind_ovos_agent_plugin.policy`` for the OVOS bridge).
     Adding new mutation kinds is the explicit, greppable way to extend
-    what policies are allowed to change. Don't introduce a free-form
-    dict-merge mutation; if there's a recurring need, add a typed
-    subclass here.
+    what policies are allowed to change on that agent's messages.
     """
 
     @abc.abstractmethod
@@ -64,105 +64,6 @@ class Mutation(abc.ABC):
         don't kill the whole admission step.
         """
         raise NotImplementedError
-
-
-@dataclass
-class AddBlacklistedSkill(Mutation):
-    """Add a skill_id to ``message.context["session"]["blacklisted_skills"]``."""
-    skill_id: str
-
-    def apply(self, message, client) -> None:
-        session = _ensure_session(message)
-        blacklist = session.setdefault("blacklisted_skills", [])
-        if self.skill_id not in blacklist:
-            blacklist.append(self.skill_id)
-
-
-@dataclass
-class AddBlacklistedIntent(Mutation):
-    """Add an intent name to ``message.context["session"]["blacklisted_intents"]``."""
-    intent_name: str
-
-    def apply(self, message, client) -> None:
-        session = _ensure_session(message)
-        blacklist = session.setdefault("blacklisted_intents", [])
-        if self.intent_name not in blacklist:
-            blacklist.append(self.intent_name)
-
-
-@dataclass
-class AddBlacklistedMessageType(Mutation):
-    """Add a Mycroft message-type pattern to a session-level message blacklist."""
-    msg_type: str
-
-    def apply(self, message, client) -> None:
-        session = _ensure_session(message)
-        blacklist = session.setdefault("blacklisted_message_types", [])
-        if self.msg_type not in blacklist:
-            blacklist.append(self.msg_type)
-
-
-@dataclass
-class SetSessionField(Mutation):
-    """Set a single key in ``message.context["session"]``."""
-    key: str
-    value: Any
-
-    def apply(self, message, client) -> None:
-        session = _ensure_session(message)
-        session[self.key] = self.value
-
-
-@dataclass
-class SetContextField(Mutation):
-    """Set a key path in ``message.context``.
-
-    ``path`` is a tuple of dict keys. Intermediate dicts are created if
-    missing. Use this when a policy needs to write outside the
-    ``session`` subtree.
-    """
-    path: Tuple[str, ...]
-    value: Any
-
-    def apply(self, message, client) -> None:
-        if not self.path:
-            return
-        target = message.context
-        if not isinstance(target, dict):
-            target = {}
-            message.context = target
-        for key in self.path[:-1]:
-            nxt = target.get(key)
-            if not isinstance(nxt, dict):
-                nxt = {}
-                target[key] = nxt
-            target = nxt
-        target[self.path[-1]] = self.value
-
-
-@dataclass
-class RewriteUtterance(Mutation):
-    """Replace the utterance text in a ``recognizer_loop:utterance``
-    Mycroft message. Silent no-op on any other ``msg_type``."""
-    text: str
-
-    def apply(self, message, client) -> None:
-        if getattr(message, "msg_type", None) != "recognizer_loop:utterance":
-            return
-        if not isinstance(message.data, dict):
-            return
-        message.data["utterances"] = [self.text]
-
-
-def _ensure_session(message) -> Dict[str, Any]:
-    """Return ``message.context["session"]``, creating it if missing."""
-    if not isinstance(message.context, dict):
-        message.context = {}
-    session = message.context.get("session")
-    if not isinstance(session, dict):
-        session = {}
-        message.context["session"] = session
-    return session
 
 
 # ---------------------------------------------------------------------------
@@ -268,10 +169,4 @@ __all__ = [
     "PolicyPlugin",
     "Verdict",
     "Mutation",
-    "AddBlacklistedSkill",
-    "AddBlacklistedIntent",
-    "AddBlacklistedMessageType",
-    "SetSessionField",
-    "SetContextField",
-    "RewriteUtterance",
 ]

--- a/hivemind_plugin_manager/policy.py
+++ b/hivemind_plugin_manager/policy.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import abc
 import dataclasses
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
 from hivemind_plugin_manager.protocols import _SubProtocol
 
@@ -137,7 +137,18 @@ class PolicyPlugin(_SubProtocol):
     exception in ``review`` / ``review_binary`` and treats it as
     ``Verdict.deny("policy_error", ...)`` (fail-closed, no operator
     knob). ``observe`` exceptions are logged and swallowed.
+
+    Class attributes (declared on the subclass, not the instance):
+
+    - :attr:`BYPASS_ADMIN`: if ``True``, this policy is skipped entirely
+      when ``client.is_admin`` is ``True``. Set this on policies that
+      enforce restrictions admins should be exempt from (whitelist
+      checks, agent-specific blacklists, session validation, etc.).
+      Default ``False`` — quotas, audit, rate-limiting and similar
+      policies should apply to admins too.
     """
+
+    BYPASS_ADMIN: ClassVar[bool] = False
 
     config: Dict[str, Any] = dataclasses.field(default_factory=dict)
     hm_protocol: Optional["HiveMindListenerProtocol"] = None

--- a/hivemind_plugin_manager/policy.py
+++ b/hivemind_plugin_manager/policy.py
@@ -1,0 +1,277 @@
+"""HiveMind policy plugin primitives.
+
+A **policy plugin** is HiveMind's admission-control point: it sees every
+Mycroft ``Message`` (and every binary payload) about to be forwarded to the
+agent bus, and can allow it, deny it, or mutate it.
+
+This module ships only the *primitives* — the plugin base class and the
+typed data the chain runner consumes. The actual chain runner lives in
+``hivemind-core`` and is the consumer of everything declared here.
+
+Three concepts:
+
+- :class:`PolicyPlugin` — the base class third-party plugins subclass and
+  register under the ``hivemind.policy`` entry-point group.
+- :class:`Verdict` — what ``review()`` returns. Either allow (optionally
+  carrying mutations) or deny (with a code, reason, and structured data
+  for the client-side denial message).
+- :class:`Mutation` — typed actions a policy can request on a message that
+  is being allowed. Stdlib subclasses cover the common cases; new mutation
+  kinds are added here so the set is greppable and the chain runner stays
+  honest about what plugins are allowed to change.
+
+Design references:
+
+- https://github.com/JarbasHiveMind/HiveMind-core/issues/85 — admission
+  chain spec.
+- The OVOS pipeline's utterance-transformer pattern — same allow/mutate/
+  veto idea, lifted from ``recognizer_loop:utterance`` to arbitrary bus
+  messages, with a typed ``Verdict`` for cross-network denial reporting.
+"""
+from __future__ import annotations
+
+import abc
+import dataclasses
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from ovos_utils.log import LOG
+
+from hivemind_plugin_manager.protocols import _SubProtocol
+
+
+# ---------------------------------------------------------------------------
+# Mutations
+# ---------------------------------------------------------------------------
+
+class Mutation(abc.ABC):
+    """A typed action a policy can request on a message being allowed.
+
+    Adding new mutation kinds is the explicit, greppable way to extend
+    what policies are allowed to change. Don't introduce a free-form
+    dict-merge mutation; if there's a recurring need, add a typed
+    subclass here.
+    """
+
+    @abc.abstractmethod
+    def apply(self, message, client) -> None:
+        """Mutate ``message`` in place. ``client`` is the
+        ``HiveMindClientConnection`` that originated the message, supplied
+        so mutations can read identity / session state if needed.
+
+        Implementations must be best-effort: an exception here is logged
+        and skipped by the chain runner, so individual mutation failures
+        don't kill the whole admission step.
+        """
+        raise NotImplementedError
+
+
+@dataclass
+class AddBlacklistedSkill(Mutation):
+    """Add a skill_id to ``message.context["session"]["blacklisted_skills"]``."""
+    skill_id: str
+
+    def apply(self, message, client) -> None:
+        session = _ensure_session(message)
+        blacklist = session.setdefault("blacklisted_skills", [])
+        if self.skill_id not in blacklist:
+            blacklist.append(self.skill_id)
+
+
+@dataclass
+class AddBlacklistedIntent(Mutation):
+    """Add an intent name to ``message.context["session"]["blacklisted_intents"]``."""
+    intent_name: str
+
+    def apply(self, message, client) -> None:
+        session = _ensure_session(message)
+        blacklist = session.setdefault("blacklisted_intents", [])
+        if self.intent_name not in blacklist:
+            blacklist.append(self.intent_name)
+
+
+@dataclass
+class AddBlacklistedMessageType(Mutation):
+    """Add a Mycroft message-type pattern to a session-level message blacklist."""
+    msg_type: str
+
+    def apply(self, message, client) -> None:
+        session = _ensure_session(message)
+        blacklist = session.setdefault("blacklisted_message_types", [])
+        if self.msg_type not in blacklist:
+            blacklist.append(self.msg_type)
+
+
+@dataclass
+class SetSessionField(Mutation):
+    """Set a single key in ``message.context["session"]``."""
+    key: str
+    value: Any
+
+    def apply(self, message, client) -> None:
+        session = _ensure_session(message)
+        session[self.key] = self.value
+
+
+@dataclass
+class SetContextField(Mutation):
+    """Set a key path in ``message.context``.
+
+    ``path`` is a tuple of dict keys. Intermediate dicts are created if
+    missing. Use this when a policy needs to write outside the
+    ``session`` subtree.
+    """
+    path: Tuple[str, ...]
+    value: Any
+
+    def apply(self, message, client) -> None:
+        if not self.path:
+            return
+        target = message.context
+        if not isinstance(target, dict):
+            target = {}
+            message.context = target
+        for key in self.path[:-1]:
+            nxt = target.get(key)
+            if not isinstance(nxt, dict):
+                nxt = {}
+                target[key] = nxt
+            target = nxt
+        target[self.path[-1]] = self.value
+
+
+@dataclass
+class RewriteUtterance(Mutation):
+    """Replace the utterance text in a ``recognizer_loop:utterance``
+    Mycroft message. Silent no-op on any other ``msg_type``."""
+    text: str
+
+    def apply(self, message, client) -> None:
+        if getattr(message, "msg_type", None) != "recognizer_loop:utterance":
+            return
+        if not isinstance(message.data, dict):
+            return
+        message.data["utterances"] = [self.text]
+
+
+def _ensure_session(message) -> Dict[str, Any]:
+    """Return ``message.context["session"]``, creating it if missing."""
+    if not isinstance(message.context, dict):
+        message.context = {}
+    session = message.context.get("session")
+    if not isinstance(session, dict):
+        session = {}
+        message.context["session"] = session
+    return session
+
+
+# ---------------------------------------------------------------------------
+# Verdict
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Verdict:
+    """The answer a :class:`PolicyPlugin` returns from ``review()``.
+
+    Either denying (the message will not be emitted; the client receives
+    a ``hive.policy.denied`` notification carrying ``code`` / ``reason`` /
+    ``data``) or allowing — optionally with one or more
+    :class:`Mutation` objects describing what the policy wants changed on
+    the message before it proceeds.
+
+    Mutations attached to a *denying* verdict are ignored. The chain
+    short-circuits on the first denial.
+    """
+
+    denied: bool = False
+    code: str = ""
+    reason: str = ""
+    data: Dict[str, Any] = field(default_factory=dict)
+    mutations: List[Mutation] = field(default_factory=list)
+
+    @classmethod
+    def allow(cls, *mutations: Mutation) -> "Verdict":
+        """Construct an allow-verdict, optionally carrying mutations."""
+        return cls(mutations=list(mutations))
+
+    @classmethod
+    def deny(cls, code: str, reason: str = "", **data: Any) -> "Verdict":
+        """Construct a deny-verdict.
+
+        ``code`` is a stable machine-readable string
+        (e.g. ``"quota_exceeded"``, ``"intent_blacklisted"``,
+        ``"policy_error"``). ``reason`` is human-readable. Extra keyword
+        arguments are forwarded into ``data`` for the client-side
+        denial message.
+        """
+        return cls(denied=True, code=code, reason=reason, data=dict(data))
+
+
+# ---------------------------------------------------------------------------
+# PolicyPlugin
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PolicyPlugin(_SubProtocol):
+    """Base class for HiveMind policy plugins.
+
+    Subclasses override ``review`` (and optionally ``review_binary``
+    / ``observe``). They are loaded by ``hivemind-core`` via the
+    ``hivemind.policy`` entry-point group and invoked in the order
+    declared by the operator's ``policy.chain`` config.
+
+    Three hooks, all synchronous (matches the broader ``_SubProtocol``
+    contract used by other plugin types in this package):
+
+    - :meth:`review` — for Mycroft ``Message`` instances. Called before
+      ``bus.emit()``.
+    - :meth:`review_binary` — for binary payloads (e.g. raw audio).
+      Default impl returns ``Verdict.allow()`` so plugins ignore
+      binaries unless they care.
+    - :meth:`observe` — called after a message was successfully
+      emitted to the bus. Use for counters, audit logs, telemetry. Must
+      not raise.
+
+    The chain runner in ``hivemind-core`` catches any unhandled
+    exception in ``review`` / ``review_binary`` and treats it as
+    ``Verdict.deny("policy_error", ...)`` (fail-closed, no operator
+    knob). ``observe`` exceptions are logged and swallowed.
+    """
+
+    config: Dict[str, Any] = dataclasses.field(default_factory=dict)
+    hm_protocol: Optional["HiveMindListenerProtocol"] = None
+
+    def review(self, message, client) -> Verdict:
+        """Inspect a Mycroft Message about to be forwarded to the agent bus.
+
+        Override to allow/deny/mutate. The default implementation allows
+        everything — subclasses are expected to be opinionated.
+        """
+        return Verdict.allow()
+
+    def review_binary(self, payload, client) -> Verdict:
+        """Inspect a binary payload about to be forwarded to the agent
+        bus. Default: allow."""
+        return Verdict.allow()
+
+    def observe(self, message, client) -> None:
+        """Called after a Message was successfully emitted to the bus.
+
+        Use for counters, audit logs, telemetry. Must not raise — if
+        you can't help yourself, wrap your code in ``try/except`` and
+        log it; the chain runner does the same as a safety net.
+        """
+        pass
+
+
+__all__ = [
+    "PolicyPlugin",
+    "Verdict",
+    "Mutation",
+    "AddBlacklistedSkill",
+    "AddBlacklistedIntent",
+    "AddBlacklistedMessageType",
+    "SetSessionField",
+    "SetContextField",
+    "RewriteUtterance",
+]

--- a/hivemind_plugin_manager/policy.py
+++ b/hivemind_plugin_manager/policy.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import abc
 import dataclasses
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from hivemind_plugin_manager.protocols import _SubProtocol
 
@@ -138,17 +138,12 @@ class PolicyPlugin(_SubProtocol):
     ``Verdict.deny("policy_error", ...)`` (fail-closed, no operator
     knob). ``observe`` exceptions are logged and swallowed.
 
-    Class attributes (declared on the subclass, not the instance):
-
-    - :attr:`BYPASS_ADMIN`: if ``True``, this policy is skipped entirely
-      when ``client.is_admin`` is ``True``. Set this on policies that
-      enforce restrictions admins should be exempt from (whitelist
-      checks, agent-specific blacklists, session validation, etc.).
-      Default ``False`` — quotas, audit, rate-limiting and similar
-      policies should apply to admins too.
+    ``Client.is_admin`` is **informational only** and the chain runner
+    does not give it any special treatment. Policies that care about
+    admin status check ``client.is_admin`` themselves inside ``review``
+    and decide what to do with it; this is just a flag the plugin
+    consumes, not a runner-level bypass switch.
     """
-
-    BYPASS_ADMIN: ClassVar[bool] = False
 
     config: Dict[str, Any] = dataclasses.field(default_factory=dict)
     hm_protocol: Optional["HiveMindListenerProtocol"] = None

--- a/hivemind_plugin_manager/policy.py
+++ b/hivemind_plugin_manager/policy.py
@@ -35,9 +35,32 @@ from __future__ import annotations
 import abc
 import dataclasses
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union
 
 from hivemind_plugin_manager.protocols import _SubProtocol
+
+
+# Reserved key on ``message.context`` used by policy plugins to share a
+# single resolved-client lookup across the chain. ``MessageTypeACLPolicy``
+# (always first) stashes the DB row here; downstream policies read it
+# instead of issuing their own DB query. Module-level constant so all
+# consumers agree on the spelling.
+RESOLVED_CLIENT_CTX_KEY = "_resolved_client"
+
+
+class DenyCodes(str, Enum):
+    """Stable machine-readable deny codes returned in :class:`Verdict`.
+
+    Stringly typed via ``str`` mixin so existing code comparing against
+    plain strings keeps working. Use ``DenyCodes.X.value`` or pass the
+    member directly to :meth:`Verdict.deny`.
+    """
+
+    POLICY_ERROR = "policy_error"
+    POLICY_CHAIN_UNAVAILABLE = "policy_chain_unavailable"
+    ACL_DISALLOWED_TYPE = "acl_disallowed_type"
+    SESSION_ID_DEFAULT_FORBIDDEN = "session_id_default_forbidden"
 
 
 # ---------------------------------------------------------------------------
@@ -54,14 +77,21 @@ class Mutation(abc.ABC):
     """
 
     @abc.abstractmethod
-    def apply(self, message, client) -> None:
-        """Mutate ``message`` in place. ``client`` is the
-        ``HiveMindClientConnection`` that originated the message, supplied
-        so mutations can read identity / session state if needed.
+    def apply(self, message, client) -> "Optional[Any]":
+        """Mutate ``message`` and return either ``None`` (in-place mutation)
+        or a replacement ``Message`` the chain runner should use going
+        forward. ``client`` is the ``HiveMindClientConnection`` that
+        originated the message, supplied so mutations can read identity /
+        session state if needed.
 
-        Implementations must be best-effort: an exception here is logged
-        and skipped by the chain runner, so individual mutation failures
-        don't kill the whole admission step.
+        Returning ``None`` is the common case — mutate in place and let
+        the chain continue with the same ``Message`` instance. Returning
+        a non-None value lets a mutation swap the message wholesale
+        (e.g. wrapping it in a new envelope) without callers having to
+        special-case that pattern.
+
+        Implementations must be best-effort: an exception here is treated
+        by the chain runner as a deny with code ``policy_error``.
         """
         raise NotImplementedError
 
@@ -96,7 +126,7 @@ class Verdict:
         return cls(mutations=list(mutations))
 
     @classmethod
-    def deny(cls, code: str, reason: str = "", **data: Any) -> "Verdict":
+    def deny(cls, code: "Union[str, DenyCodes]", reason: str = "", **data: Any) -> "Verdict":
         """Construct a deny-verdict.
 
         ``code`` is a stable machine-readable string
@@ -105,7 +135,8 @@ class Verdict:
         arguments are forwarded into ``data`` for the client-side
         denial message.
         """
-        return cls(denied=True, code=code, reason=reason, data=dict(data))
+        code_str = code.value if isinstance(code, DenyCodes) else str(code)
+        return cls(denied=True, code=code_str, reason=reason, data=dict(data))
 
 
 # ---------------------------------------------------------------------------
@@ -175,4 +206,6 @@ __all__ = [
     "PolicyPlugin",
     "Verdict",
     "Mutation",
+    "DenyCodes",
+    "RESOLVED_CLIENT_CTX_KEY",
 ]

--- a/hivemind_plugin_manager/policy.py
+++ b/hivemind_plugin_manager/policy.py
@@ -92,7 +92,7 @@ class Mutation(abc.ABC):
 # Verdict
 # ---------------------------------------------------------------------------
 
-@dataclass
+@dataclass(frozen=True)
 class Verdict:
     """The answer a :class:`PolicyPlugin` returns from ``review()``.
 
@@ -179,7 +179,7 @@ class PolicyPlugin(_SubProtocol):
         """
         return Verdict.allow()
 
-    def review_binary(self, payload, client) -> Verdict:
+    def review_binary(self, payload: bytes, client) -> Verdict:
         """Inspect a binary payload about to be forwarded to the agent
         bus. Default: allow."""
         return Verdict.allow()

--- a/hivemind_plugin_manager/policy.py
+++ b/hivemind_plugin_manager/policy.py
@@ -41,14 +41,6 @@ from typing import Any, Dict, List, Optional, Union
 from hivemind_plugin_manager.protocols import _SubProtocol
 
 
-# Reserved key on ``message.context`` used by policy plugins to share a
-# single resolved-client lookup across the chain. ``MessageTypeACLPolicy``
-# (always first) stashes the DB row here; downstream policies read it
-# instead of issuing their own DB query. Module-level constant so all
-# consumers agree on the spelling.
-RESOLVED_CLIENT_CTX_KEY = "_resolved_client"
-
-
 class DenyCodes(str, Enum):
     """Stable machine-readable deny codes returned in :class:`Verdict`.
 
@@ -207,5 +199,4 @@ __all__ = [
     "Verdict",
     "Mutation",
     "DenyCodes",
-    "RESOLVED_CLIENT_CTX_KEY",
 ]

--- a/tests/e2e/test_policy_e2e.py
+++ b/tests/e2e/test_policy_e2e.py
@@ -1,0 +1,389 @@
+"""E2E contract tests for PolicyPlugin / Verdict using hivescope topology.
+
+These tests verify the admission-control contract that ``hivemind-core``'s
+chain runner (HiveMind-core#89) will consume.  The chain runner does not
+exist yet; this file pins the expected behaviour so that integration is
+provably correct when it lands.
+
+Pattern: each test builds a minimal hivescope topology, runs messages
+through a ``PolicyPlugin.review()`` call that simulates the chain runner,
+and asserts the outcome with ``assert_acl_enforced``.
+
+Two sets of tests:
+
+1. ``TestPolicyContractSimulated`` — pure in-memory, no live
+   network. Uses hivescope's ``InMemoryClientDatabase`` and
+   ``MasterNode`` / ``SatelliteNode`` helpers for the client context but
+   routes messages through the policy manually (mirrors the logic the
+   chain runner will implement).
+
+2. ``TestPolicyIntegration`` — uses hivescope's ``single_satellite``
+   scenario builder to spin up a full in-process topology.  Policies are
+   applied before ``SatelliteNode.send()`` to verify that
+   ``assert_acl_enforced`` correctly reports whether a message reached
+   master.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from ovos_bus_client.message import Message
+
+from hivemind_plugin_manager import Mutation, PolicyPlugin, Verdict
+from hivemind_plugin_manager.policy import DenyCodes
+
+from hivescope import assert_acl_enforced
+from hivescope.scenarios import single_satellite
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _FakeClient:
+    """Minimal HiveMindClientConnection stand-in for unit scenarios."""
+
+    def __init__(self, name="test-client", is_admin=False):
+        self.name = name
+        self.is_admin = is_admin
+        self.peer = f"{name}@127.0.0.1:9999"
+        self.user = MagicMock(name="user")
+        self.user.metadata = {}
+
+
+def _run_chain(policies, message, client):
+    """Simulate the chain-runner logic (fail-closed on exception)."""
+    for policy in policies:
+        try:
+            verdict = policy.review(message, client)
+        except Exception as exc:
+            return Verdict.deny(DenyCodes.POLICY_ERROR, str(exc))
+        if verdict.denied:
+            return verdict
+        for mutation in verdict.mutations:
+            try:
+                result = mutation.apply(message, client)
+                if result is not None:
+                    message = result
+            except Exception:
+                pass  # chain runner skips failed mutations
+    return Verdict.allow()
+
+
+# ---------------------------------------------------------------------------
+# PolicyPlugin contract: simulated chain
+# ---------------------------------------------------------------------------
+
+class TestPolicyContractSimulated(unittest.TestCase):
+    """Verify PolicyPlugin/Verdict behaviour without a live network."""
+
+    # -- deny-all policy --
+
+    def test_deny_all_policy_denies_every_message(self):
+        class DenyAll(PolicyPlugin):
+            def review(self, message, client) -> Verdict:
+                return Verdict.deny("always_denied", "deny-all policy active")
+
+        policy = DenyAll()
+        msg = MagicMock(name="message", msg_type="speak")
+        client = _FakeClient()
+
+        verdict = policy.review(msg, client)
+        self.assertTrue(verdict.denied)
+        self.assertEqual(verdict.code, "always_denied")
+        self.assertEqual(verdict.reason, "deny-all policy active")
+
+    # -- allow-all policy (default impl) --
+
+    def test_default_policy_allows_every_message(self):
+        policy = PolicyPlugin()
+        msg = MagicMock(name="message", msg_type="recognizer_loop:utterance")
+        client = _FakeClient()
+
+        verdict = policy.review(msg, client)
+        self.assertFalse(verdict.denied)
+        self.assertEqual(verdict.mutations, [])
+
+    # -- chain: first deny short-circuits --
+
+    def test_chain_short_circuits_on_first_deny(self):
+        call_log = []
+
+        class AlwaysDeny(PolicyPlugin):
+            def review(self, message, client) -> Verdict:
+                call_log.append("deny")
+                return Verdict.deny("blocked", "first policy denied")
+
+        class ShouldNotRun(PolicyPlugin):
+            def review(self, message, client) -> Verdict:
+                call_log.append("second")
+                return Verdict.allow()
+
+        chain = [AlwaysDeny(), ShouldNotRun()]
+        msg = MagicMock(msg_type="speak")
+        client = _FakeClient()
+
+        verdict = _run_chain(chain, msg, client)
+
+        self.assertTrue(verdict.denied)
+        self.assertEqual(verdict.code, "blocked")
+        self.assertNotIn("second", call_log, "chain must not continue past a deny")
+
+    # -- chain: allow passes through --
+
+    def test_chain_allow_passes_all_policies(self):
+        call_log = []
+
+        class CountingPolicy(PolicyPlugin):
+            def review(self, message, client) -> Verdict:
+                call_log.append("ran")
+                return Verdict.allow()
+
+        chain = [CountingPolicy(), CountingPolicy(), CountingPolicy()]
+        msg = MagicMock(msg_type="speak")
+        client = _FakeClient()
+
+        verdict = _run_chain(chain, msg, client)
+
+        self.assertFalse(verdict.denied)
+        self.assertEqual(len(call_log), 3)
+
+    # -- chain: fail-closed on exception --
+
+    def test_chain_fail_closed_on_review_exception(self):
+        class CrashingPolicy(PolicyPlugin):
+            def review(self, message, client) -> Verdict:
+                raise RuntimeError("unexpected internal error")
+
+        chain = [CrashingPolicy()]
+        msg = MagicMock(msg_type="speak")
+        client = _FakeClient()
+
+        verdict = _run_chain(chain, msg, client)
+
+        self.assertTrue(verdict.denied)
+        self.assertEqual(verdict.code, DenyCodes.POLICY_ERROR)
+
+    # -- mutation application --
+
+    def test_mutation_applied_on_allow(self):
+        class TagMessage(Mutation):
+            def apply(self, message, client):
+                message.context["tagged"] = True
+                return None
+
+        class TaggingPolicy(PolicyPlugin):
+            def review(self, message, client) -> Verdict:
+                return Verdict.allow(TagMessage())
+
+        class FakeMessage:
+            def __init__(self):
+                self.msg_type = "speak"
+                self.context = {}
+
+        msg = FakeMessage()
+        chain = [TaggingPolicy()]
+        client = _FakeClient()
+
+        verdict = _run_chain(chain, msg, client)
+
+        self.assertFalse(verdict.denied)
+        self.assertTrue(msg.context.get("tagged"), "mutation must have been applied")
+
+    # -- mutations ignored on deny --
+
+    def test_mutations_ignored_on_deny(self):
+        applied = []
+
+        class MutateAndDeny(Mutation):
+            def apply(self, message, client):
+                applied.append(True)
+                return None
+
+        class DenyWithMutation(PolicyPlugin):
+            def review(self, message, client) -> Verdict:
+                return Verdict.deny("denied", mutations=[MutateAndDeny()])
+
+        chain = [DenyWithMutation()]
+        msg = MagicMock(msg_type="speak")
+        client = _FakeClient()
+
+        verdict = _run_chain(chain, msg, client)
+
+        self.assertTrue(verdict.denied)
+        self.assertEqual(applied, [], "mutations on a deny verdict must not be applied")
+
+    # -- admin is informational only --
+
+    def test_admin_status_is_informational_only(self):
+        """chain runner does not bypass policies for admin clients"""
+        class DenyAll(PolicyPlugin):
+            def review(self, message, client) -> Verdict:
+                return Verdict.deny("blocked")
+
+        admin_client = _FakeClient(is_admin=True)
+        msg = MagicMock(msg_type="speak")
+        verdict = _run_chain([DenyAll()], msg, admin_client)
+
+        self.assertTrue(verdict.denied, "admin client must still be denied by DenyAll")
+
+    # -- DenyCodes enum usable in deny() --
+
+    def test_deny_accepts_deny_codes_enum(self):
+        v = Verdict.deny(DenyCodes.ACL_DISALLOWED_TYPE, "not in allowed_types")
+        self.assertTrue(v.denied)
+        self.assertEqual(v.code, "acl_disallowed_type")
+
+    # -- observe never blocks delivery --
+
+    def test_observe_exception_does_not_propagate(self):
+        class BadObserver(PolicyPlugin):
+            def observe(self, message, client) -> None:
+                raise RuntimeError("observer crashed")
+
+        policy = BadObserver()
+        msg = MagicMock(msg_type="speak")
+        client = _FakeClient()
+
+        # Simulate chain runner swallowing observe exceptions
+        try:
+            policy.observe(msg, client)
+            self.fail("expected RuntimeError from BadObserver.observe()")
+        except RuntimeError:
+            pass  # chain runner catches this; the test proves it does raise,
+                  # so the runner MUST wrap it in try/except
+
+
+# ---------------------------------------------------------------------------
+# Integration: policy verdict gates assert_acl_enforced
+# ---------------------------------------------------------------------------
+
+class TestPolicyIntegration(unittest.TestCase):
+    """
+    Spin up a real in-process hivescope topology and verify that a policy's
+    Verdict.deny correctly prevents a message from reaching master — matching
+    what assert_acl_enforced() checks.
+    """
+
+    def test_deny_verdict_blocks_message_from_master(self):
+        """
+        A message vetoed by a DenyAll policy must not appear in master's
+        recorder; assert_acl_enforced(allowed=False) must pass.
+        """
+        b = single_satellite()
+        b.start_all()
+        try:
+            master = b.get_master("M0")
+            satellite = b.get_satellite("S0")
+
+            class DenyAll(PolicyPlugin):
+                def review(self, message, client) -> Verdict:
+                    return Verdict.deny("blocked_by_policy")
+
+            policy = DenyAll()
+
+            # Simulate what the chain runner will do: call review() and only
+            # forward to the satellite if allowed.
+            test_msg = Message("speak", {"utterance": "hello"})
+            fake_client = _FakeClient()
+            verdict = policy.review(test_msg, fake_client)
+
+            # Policy denied — do NOT send the message (chain runner behaviour)
+            self.assertTrue(verdict.denied)
+
+            # Message was never sent — assert_acl_enforced must confirm it
+            # never reached master (allowed=False = "it was blocked").
+            assert_acl_enforced(master, satellite, "speak", allowed=False)
+        finally:
+            b.stop_all()
+
+    def test_allow_verdict_permits_message_to_reach_master(self):
+        """
+        A message approved by a PolicyPlugin must reach master; the chain
+        runner forwards it and assert_bus_message_routed() must confirm receipt.
+
+        Note: assert_acl_enforced() matches on the HiveMessageType envelope
+        level (e.g. ``"bus"``, ``"broadcast"``), not the inner OVOS message
+        type. For BUS messages we use assert_bus_message_routed() instead.
+        """
+        from hivescope.assertions import assert_bus_message_routed
+
+        b = single_satellite()
+        b.start_all()
+        try:
+            master = b.get_master("M0")
+            satellite = b.get_satellite("S0")
+
+            class AllowAll(PolicyPlugin):
+                def review(self, message, client) -> Verdict:
+                    return Verdict.allow()
+
+            policy = AllowAll()
+
+            # Use an admin satellite so hivemind-core accepts the message
+            # (non-admin clients cannot inject default-session messages).
+            # For this test we register an admin key and reconnect.
+            hive_msg = HiveMessage(
+                HiveMessageType.BUS,
+                payload=Message("speak", {"utterance": "hello"}),
+            )
+            fake_client = _FakeClient()
+            verdict = policy.review(hive_msg.payload, fake_client)
+
+            # Policy allowed — send the message (chain runner behaviour)
+            self.assertFalse(verdict.denied)
+            satellite.send(hive_msg)
+
+            # BUS message must reach master within 2s (recorded as HiveMessageType.BUS)
+            master.recorder.wait_for(HiveMessageType.BUS.value, direction="in", timeout=2.0)
+            assert_bus_message_routed(master, count=1)
+        finally:
+            b.stop_all()
+
+    def test_static_acl_allowed_types_deny(self):
+        """
+        Regression: the static allowed_types whitelist (deny-by-default
+        when non-empty and msg_type not in it) must block the message before
+        it reaches master. This is the built-in ACL policy that hivemind-core
+        migrates into a PolicyPlugin in the next PR; we verify the underlying
+        primitive here.
+        """
+        from hivemind_plugin_manager.database import Client
+
+        b = single_satellite()
+        b.start_all()
+        try:
+            master = b.get_master("M0")
+            satellite = b.get_satellite("S0")
+
+            # Simulate a policy plugin that enforces allowed_types = ["ping"]
+            # (i.e., "speak" must be denied)
+            allowed = ["ping"]
+
+            class AllowedTypesPolicy(PolicyPlugin):
+                def review(self, message, client) -> Verdict:
+                    if allowed and message.msg_type not in allowed:
+                        return Verdict.deny(
+                            DenyCodes.ACL_DISALLOWED_TYPE,
+                            f"{message.msg_type!r} not in allowed_types",
+                        )
+                    return Verdict.allow()
+
+            policy = AllowedTypesPolicy()
+            test_msg = Message("speak", {"utterance": "blocked"})
+            fake_client = _FakeClient()
+            verdict = policy.review(test_msg, fake_client)
+
+            self.assertTrue(verdict.denied)
+            self.assertEqual(verdict.code, "acl_disallowed_type")
+
+            # Message not forwarded
+            assert_acl_enforced(master, satellite, "speak", allowed=False)
+        finally:
+            b.stop_all()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_policy_e2e.py
+++ b/tests/e2e/test_policy_e2e.py
@@ -1,27 +1,10 @@
-"""E2E contract tests for PolicyPlugin / Verdict using hivescope topology.
+"""Contract tests for ``PolicyPlugin`` / ``Verdict`` / ``Mutation``.
 
-These tests verify the admission-control contract that ``hivemind-core``'s
-chain runner (HiveMind-core#89) will consume.  The chain runner does not
-exist yet; this file pins the expected behaviour so that integration is
-provably correct when it lands.
-
-Pattern: each test builds a minimal hivescope topology, runs messages
-through a ``PolicyPlugin.review()`` call that simulates the chain runner,
-and asserts the outcome with ``assert_acl_enforced``.
-
-Two sets of tests:
-
-1. ``TestPolicyContractSimulated`` — pure in-memory, no live
-   network. Uses hivescope's ``InMemoryClientDatabase`` and
-   ``MasterNode`` / ``SatelliteNode`` helpers for the client context but
-   routes messages through the policy manually (mirrors the logic the
-   chain runner will implement).
-
-2. ``TestPolicyIntegration`` — uses hivescope's ``single_satellite``
-   scenario builder to spin up a full in-process topology.  Policies are
-   applied before ``SatelliteNode.send()`` to verify that
-   ``assert_acl_enforced`` correctly reports whether a message reached
-   master.
+Each test drives messages through ``PolicyPlugin.review()`` and the
+chain semantics (short-circuit on first deny, fail-closed on exception,
+mutations applied on allow only) against an in-memory ``_FakeClient``
+context. No network and no consumer packages — this pins the admission
+contract that ``hivemind-core``'s chain runner consumes.
 """
 from __future__ import annotations
 
@@ -34,8 +17,6 @@ from ovos_bus_client.message import Message
 from hivemind_plugin_manager import Mutation, PolicyPlugin, Verdict
 from hivemind_plugin_manager.policy import DenyCodes
 
-from hivescope import assert_acl_enforced
-from hivescope.scenarios import single_satellite
 
 
 # ---------------------------------------------------------------------------
@@ -253,137 +234,5 @@ class TestPolicyContractSimulated(unittest.TestCase):
             self.fail("expected RuntimeError from BadObserver.observe()")
         except RuntimeError:
             pass  # chain runner catches this; the test proves it does raise,
-                  # so the runner MUST wrap it in try/except
-
-
-# ---------------------------------------------------------------------------
-# Integration: policy verdict gates assert_acl_enforced
-# ---------------------------------------------------------------------------
-
-class TestPolicyIntegration(unittest.TestCase):
-    """
-    Spin up a real in-process hivescope topology and verify that a policy's
-    Verdict.deny correctly prevents a message from reaching master — matching
-    what assert_acl_enforced() checks.
-    """
-
-    def test_deny_verdict_blocks_message_from_master(self):
-        """
-        A message vetoed by a DenyAll policy must not appear in master's
-        recorder; assert_acl_enforced(allowed=False) must pass.
-        """
-        b = single_satellite()
-        b.start_all()
-        try:
-            master = b.get_master("M0")
-            satellite = b.get_satellite("S0")
-
-            class DenyAll(PolicyPlugin):
-                def review(self, message, client) -> Verdict:
-                    return Verdict.deny("blocked_by_policy")
-
-            policy = DenyAll()
-
-            # Simulate what the chain runner will do: call review() and only
-            # forward to the satellite if allowed.
-            test_msg = Message("speak", {"utterance": "hello"})
-            fake_client = _FakeClient()
-            verdict = policy.review(test_msg, fake_client)
-
-            # Policy denied — do NOT send the message (chain runner behaviour)
-            self.assertTrue(verdict.denied)
-
-            # Message was never sent — assert_acl_enforced must confirm it
-            # never reached master (allowed=False = "it was blocked").
-            assert_acl_enforced(master, satellite, "speak", allowed=False)
-        finally:
-            b.stop_all()
-
-    def test_allow_verdict_permits_message_to_reach_master(self):
-        """
-        A message approved by a PolicyPlugin must reach master; the chain
-        runner forwards it and assert_bus_message_routed() must confirm receipt.
-
-        Note: assert_acl_enforced() matches on the HiveMessageType envelope
-        level (e.g. ``"bus"``, ``"broadcast"``), not the inner OVOS message
-        type. For BUS messages we use assert_bus_message_routed() instead.
-        """
-        from hivescope.assertions import assert_bus_message_routed
-
-        b = single_satellite()
-        b.start_all()
-        try:
-            master = b.get_master("M0")
-            satellite = b.get_satellite("S0")
-
-            class AllowAll(PolicyPlugin):
-                def review(self, message, client) -> Verdict:
-                    return Verdict.allow()
-
-            policy = AllowAll()
-
-            # Use an admin satellite so hivemind-core accepts the message
-            # (non-admin clients cannot inject default-session messages).
-            # For this test we register an admin key and reconnect.
-            hive_msg = HiveMessage(
-                HiveMessageType.BUS,
-                payload=Message("speak", {"utterance": "hello"}),
-            )
-            fake_client = _FakeClient()
-            verdict = policy.review(hive_msg.payload, fake_client)
-
-            # Policy allowed — send the message (chain runner behaviour)
-            self.assertFalse(verdict.denied)
-            satellite.send(hive_msg)
-
-            # BUS message must reach master within 2s (recorded as HiveMessageType.BUS)
-            master.recorder.wait_for(HiveMessageType.BUS.value, direction="in", timeout=2.0)
-            assert_bus_message_routed(master, count=1)
-        finally:
-            b.stop_all()
-
-    def test_static_acl_allowed_types_deny(self):
-        """
-        Regression: the static allowed_types whitelist (deny-by-default
-        when non-empty and msg_type not in it) must block the message before
-        it reaches master. This is the built-in ACL policy that hivemind-core
-        migrates into a PolicyPlugin in the next PR; we verify the underlying
-        primitive here.
-        """
-        from hivemind_plugin_manager.database import Client
-
-        b = single_satellite()
-        b.start_all()
-        try:
-            master = b.get_master("M0")
-            satellite = b.get_satellite("S0")
-
-            # Simulate a policy plugin that enforces allowed_types = ["ping"]
-            # (i.e., "speak" must be denied)
-            allowed = ["ping"]
-
-            class AllowedTypesPolicy(PolicyPlugin):
-                def review(self, message, client) -> Verdict:
-                    if allowed and message.msg_type not in allowed:
-                        return Verdict.deny(
-                            DenyCodes.ACL_DISALLOWED_TYPE,
-                            f"{message.msg_type!r} not in allowed_types",
-                        )
-                    return Verdict.allow()
-
-            policy = AllowedTypesPolicy()
-            test_msg = Message("speak", {"utterance": "blocked"})
-            fake_client = _FakeClient()
-            verdict = policy.review(test_msg, fake_client)
-
-            self.assertTrue(verdict.denied)
-            self.assertEqual(verdict.code, "acl_disallowed_type")
-
-            # Message not forwarded
-            assert_acl_enforced(master, satellite, "speak", allowed=False)
-        finally:
-            b.stop_all()
-
-
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_client_deserialize.py
+++ b/tests/test_client_deserialize.py
@@ -43,9 +43,12 @@ class TestClientDeserialize(unittest.TestCase):
         c = Client.deserialize(self._base(metadata=None))
         self.assertEqual(c.metadata, {})
 
-    def test_non_dict_metadata_raises(self):
-        with self.assertRaises(TypeError):
-            Client.deserialize(self._base(metadata="nope"))
+    def test_non_dict_metadata_coerced_to_empty(self):
+        # consistent with Client.__post_init__: a non-dict metadata payload
+        # falls back to {} so on-disk records keep loading.
+        for bad in ("nope", ["a"], 42):
+            c = Client.deserialize(self._base(metadata=bad))
+            self.assertEqual(c.metadata, {})
 
     def test_deserialize_does_not_mutate_input(self):
         payload = self._base(weird=42, metadata={"a": 1})

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -251,5 +251,126 @@ class TestAbstractRemoteDB(unittest.TestCase):
         self.assertEqual(db.search_by_value("name", "x")[0].client_id, 1)
 
 
+class TestDeprecatedBlacklistShims(unittest.TestCase):
+    """Read/write back-compat for the legacy top-level blacklist fields.
+
+    Canonical storage is now ``Client.metadata``; legacy callers keep
+    working via property shims and the deserialize() migration path.
+    """
+
+    @staticmethod
+    def _catch_warnings():
+        import warnings
+        ctx = warnings.catch_warnings(record=True)
+        caught = ctx.__enter__()
+        warnings.simplefilter("always")
+        return ctx, caught
+
+    @staticmethod
+    def _assert_has_deprecation(caught, name: str):
+        msgs = [str(w.message) for w in caught
+                if issubclass(w.category, DeprecationWarning)]
+        assert any(name in m for m in msgs), (
+            f"expected a DeprecationWarning mentioning {name!r}; got {msgs}"
+        )
+
+    def test_property_getter_reads_from_metadata(self):
+        c = Client(client_id=1, api_key="k",
+                   metadata={"skill_blacklist": ["weather.skill"]})
+        self.assertEqual(c.skill_blacklist, ["weather.skill"])
+
+    def test_property_getter_returns_snapshot(self):
+        c = Client(client_id=1, api_key="k",
+                   metadata={"skill_blacklist": ["a"]})
+        out = c.skill_blacklist
+        out.append("b")  # mutating the snapshot must not affect metadata
+        self.assertEqual(c.metadata["skill_blacklist"], ["a"])
+
+    def test_property_getter_empty_when_missing(self):
+        c = Client(client_id=1, api_key="k")
+        self.assertEqual(c.skill_blacklist, [])
+        self.assertEqual(c.intent_blacklist, [])
+        self.assertEqual(c.message_blacklist, [])
+
+    def test_property_setter_writes_to_metadata_and_warns(self):
+        c = Client(client_id=1, api_key="k")
+        ctx, caught = self._catch_warnings()
+        try:
+            c.skill_blacklist = ["a", "b"]
+        finally:
+            ctx.__exit__(None, None, None)
+        self._assert_has_deprecation(caught, "skill_blacklist")
+        self.assertEqual(c.metadata["skill_blacklist"], ["a", "b"])
+
+    def test_property_setter_clears_when_empty(self):
+        c = Client(client_id=1, api_key="k",
+                   metadata={"skill_blacklist": ["a"]})
+        ctx, caught = self._catch_warnings()
+        try:
+            c.skill_blacklist = []
+        finally:
+            ctx.__exit__(None, None, None)
+        self._assert_has_deprecation(caught, "skill_blacklist")
+        self.assertNotIn("skill_blacklist", c.metadata)
+
+    def test_deserialize_migrates_legacy_top_level_and_warns(self):
+        payload = {
+            "client_id": 1, "api_key": "k",
+            "skill_blacklist": ["s"],
+            "intent_blacklist": ["i"],
+            "message_blacklist": ["m"],
+        }
+        ctx, caught = self._catch_warnings()
+        try:
+            c = Client.deserialize(payload)
+        finally:
+            ctx.__exit__(None, None, None)
+        self._assert_has_deprecation(caught, "skill_blacklist")
+        self._assert_has_deprecation(caught, "intent_blacklist")
+        self._assert_has_deprecation(caught, "message_blacklist")
+        self.assertEqual(c.metadata["skill_blacklist"], ["s"])
+        self.assertEqual(c.metadata["intent_blacklist"], ["i"])
+        self.assertEqual(c.metadata["message_blacklist"], ["m"])
+
+    def test_deserialize_does_not_clobber_existing_metadata(self):
+        payload = {
+            "client_id": 1, "api_key": "k",
+            "skill_blacklist": ["legacy"],
+            "metadata": {"skill_blacklist": ["from_metadata"]},
+        }
+        ctx, _ = self._catch_warnings()
+        try:
+            c = Client.deserialize(payload)
+        finally:
+            ctx.__exit__(None, None, None)
+        # explicit metadata wins
+        self.assertEqual(c.metadata["skill_blacklist"], ["from_metadata"])
+
+    def test_deserialize_no_warning_when_no_legacy_keys(self):
+        ctx, caught = self._catch_warnings()
+        try:
+            c = Client.deserialize({
+                "client_id": 1, "api_key": "k",
+                "metadata": {"skill_blacklist": ["x"]},
+            })
+        finally:
+            ctx.__exit__(None, None, None)
+        deprecations = [w for w in caught
+                        if issubclass(w.category, DeprecationWarning)]
+        self.assertEqual(deprecations, [])
+        self.assertEqual(c.skill_blacklist, ["x"])
+
+    def test_deserialize_empty_legacy_value_does_not_warn(self):
+        ctx, caught = self._catch_warnings()
+        try:
+            Client.deserialize({"client_id": 1, "api_key": "k",
+                                "skill_blacklist": []})
+        finally:
+            ctx.__exit__(None, None, None)
+        deprecations = [w for w in caught
+                        if issubclass(w.category, DeprecationWarning)]
+        self.assertEqual(deprecations, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -360,6 +360,27 @@ class TestDeprecatedBlacklistShims(unittest.TestCase):
         self.assertEqual(deprecations, [])
         self.assertEqual(c.skill_blacklist, ["x"])
 
+    def test_legacy_constructor_kwarg_migrates_and_warns(self):
+        ctx, caught = self._catch_warnings()
+        try:
+            c = Client(client_id=1, api_key="k",
+                       skill_blacklist=["weather.skill"])
+        finally:
+            ctx.__exit__(None, None, None)
+        self._assert_has_deprecation(caught, "skill_blacklist")
+        self.assertEqual(c.metadata["skill_blacklist"], ["weather.skill"])
+
+    def test_legacy_constructor_kwarg_does_not_clobber_metadata(self):
+        ctx, _ = self._catch_warnings()
+        try:
+            c = Client(client_id=1, api_key="k",
+                       metadata={"skill_blacklist": ["from_meta"]},
+                       skill_blacklist=["from_kwarg"])
+        finally:
+            ctx.__exit__(None, None, None)
+        # explicit metadata wins
+        self.assertEqual(c.metadata["skill_blacklist"], ["from_meta"])
+
     def test_deserialize_empty_legacy_value_does_not_warn(self):
         ctx, caught = self._catch_warnings()
         try:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -292,22 +292,30 @@ class TestDeprecatedBlacklistShims(unittest.TestCase):
         self.assertEqual(c.skill_blacklist, [])
         self.assertEqual(c.intent_blacklist, [])
 
-    def test_message_blacklist_removed_entirely(self):
+    def test_message_blacklist_kwarg_accepted_but_discarded(self):
         """message_blacklist was a design mistake from 2024-12-20
-        (commit 94a2141) — no property, no kwarg, no carry-forward.
-        Callers can still stash a value in ``metadata`` themselves if
-        they want, but the data model does not surface it."""
+        (commit 94a2141) — no property and no carry-forward. The kwarg
+        is still ACCEPTED (not TypeError) so already-shipped backends
+        passing it positionally don't crash on partial HPM upgrades.
+        The value is discarded with a DeprecationWarning."""
         # No property at the class level.
         self.assertFalse(hasattr(type(Client(client_id=1, api_key="k")),
                                   "message_blacklist"))
-        # Constructor kwarg raises — caller is using a removed API.
-        with self.assertRaises(TypeError):
-            Client(client_id=1, api_key="k", message_blacklist=["speak"])
+        # Constructor kwarg is accepted but emits a warning and
+        # discards the value — NOT carried into metadata.
+        ctx, caught = self._catch_warnings()
+        try:
+            c = Client(client_id=1, api_key="k",
+                       message_blacklist=["speak"])
+        finally:
+            ctx.__exit__(None, None, None)
+        self._assert_has_deprecation(caught, "message_blacklist")
+        self.assertNotIn("message_blacklist", c.metadata)
         # Caller-supplied metadata key is still stored untouched (it's
         # just a dict — Client doesn't claim that key as special).
-        c = Client(client_id=1, api_key="k",
-                   metadata={"message_blacklist": ["speak"]})
-        self.assertEqual(c.metadata["message_blacklist"], ["speak"])
+        c2 = Client(client_id=1, api_key="k",
+                    metadata={"message_blacklist": ["speak"]})
+        self.assertEqual(c2.metadata["message_blacklist"], ["speak"])
 
     def test_property_setter_writes_to_metadata_and_warns(self):
         c = Client(client_id=1, api_key="k")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -292,14 +292,21 @@ class TestDeprecatedBlacklistShims(unittest.TestCase):
         self.assertEqual(c.skill_blacklist, [])
         self.assertEqual(c.intent_blacklist, [])
 
-    def test_message_blacklist_property_removed(self):
-        """v0.6: ``Client.message_blacklist`` property was dropped because
-        hivemind-core has no consumer (whitelist-only model). The legacy
-        kwarg path still migrates the value into metadata for any
-        third-party plugin that wants it."""
+    def test_message_blacklist_removed_entirely(self):
+        """message_blacklist was a design mistake from 2024-12-20
+        (commit 94a2141) — no property, no kwarg, no carry-forward.
+        Callers can still stash a value in ``metadata`` themselves if
+        they want, but the data model does not surface it."""
+        # No property at the class level.
+        self.assertFalse(hasattr(type(Client(client_id=1, api_key="k")),
+                                  "message_blacklist"))
+        # Constructor kwarg raises — caller is using a removed API.
+        with self.assertRaises(TypeError):
+            Client(client_id=1, api_key="k", message_blacklist=["speak"])
+        # Caller-supplied metadata key is still stored untouched (it's
+        # just a dict — Client doesn't claim that key as special).
         c = Client(client_id=1, api_key="k",
                    metadata={"message_blacklist": ["speak"]})
-        self.assertFalse(hasattr(type(c), "message_blacklist"))
         self.assertEqual(c.metadata["message_blacklist"], ["speak"])
 
     def test_property_setter_writes_to_metadata_and_warns(self):
@@ -328,7 +335,7 @@ class TestDeprecatedBlacklistShims(unittest.TestCase):
             "client_id": 1, "api_key": "k",
             "skill_blacklist": ["s"],
             "intent_blacklist": ["i"],
-            "message_blacklist": ["m"],
+            "message_blacklist": ["m"],  # dropped silently, no carry-forward
         }
         ctx, caught = self._catch_warnings()
         try:
@@ -337,10 +344,12 @@ class TestDeprecatedBlacklistShims(unittest.TestCase):
             ctx.__exit__(None, None, None)
         self._assert_has_deprecation(caught, "skill_blacklist")
         self._assert_has_deprecation(caught, "intent_blacklist")
-        self._assert_has_deprecation(caught, "message_blacklist")
         self.assertEqual(c.metadata["skill_blacklist"], ["s"])
         self.assertEqual(c.metadata["intent_blacklist"], ["i"])
-        self.assertEqual(c.metadata["message_blacklist"], ["m"])
+        # message_blacklist is removed outright: not carried into metadata
+        # and no DeprecationWarning emitted (it's not "deprecated" — it's
+        # gone, and silently dropping the key is the back-compat path).
+        self.assertNotIn("message_blacklist", c.metadata)
 
     def test_deserialize_does_not_clobber_existing_metadata(self):
         payload = {

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -58,15 +58,16 @@ class TestClient(unittest.TestCase):
         defaults.update(overrides)
         return Client(**defaults)
 
-    def test_defaults_populate_allowed_types(self):
+    def test_empty_allowed_types_stays_empty(self):
+        """Deny-by-default: no auto-populate, no auto-append."""
         c = self._make()
-        self.assertIn("recognizer_loop:utterance", c.allowed_types)
-        self.assertGreater(len(c.allowed_types), 1)
+        self.assertEqual(c.allowed_types, [])
 
-    def test_allowed_types_always_contains_utterance(self):
+    def test_explicit_allowed_types_preserved_exactly(self):
+        """No auto-append of recognizer_loop:utterance — operators
+        grant types explicitly."""
         c = self._make(allowed_types=["custom:event"])
-        self.assertIn("recognizer_loop:utterance", c.allowed_types)
-        self.assertIn("custom:event", c.allowed_types)
+        self.assertEqual(c.allowed_types, ["custom:event"])
 
     def test_post_init_rejects_non_int_client_id(self):
         with self.assertRaises(ValueError):
@@ -290,7 +291,16 @@ class TestDeprecatedBlacklistShims(unittest.TestCase):
         c = Client(client_id=1, api_key="k")
         self.assertEqual(c.skill_blacklist, [])
         self.assertEqual(c.intent_blacklist, [])
-        self.assertEqual(c.message_blacklist, [])
+
+    def test_message_blacklist_property_removed(self):
+        """v0.6: ``Client.message_blacklist`` property was dropped because
+        hivemind-core has no consumer (whitelist-only model). The legacy
+        kwarg path still migrates the value into metadata for any
+        third-party plugin that wants it."""
+        c = Client(client_id=1, api_key="k",
+                   metadata={"message_blacklist": ["speak"]})
+        self.assertFalse(hasattr(type(c), "message_blacklist"))
+        self.assertEqual(c.metadata["message_blacklist"], ["speak"])
 
     def test_property_setter_writes_to_metadata_and_warns(self):
         c = Client(client_id=1, api_key="k")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -293,11 +293,10 @@ class TestDeprecatedBlacklistShims(unittest.TestCase):
         self.assertEqual(c.intent_blacklist, [])
 
     def test_message_blacklist_kwarg_accepted_but_discarded(self):
-        """message_blacklist was a design mistake from 2024-12-20
-        (commit 94a2141) — no property and no carry-forward. The kwarg
-        is still ACCEPTED (not TypeError) so already-shipped backends
-        passing it positionally don't crash on partial HPM upgrades.
-        The value is discarded with a DeprecationWarning."""
+        """``message_blacklist`` is not part of the data model. The
+        kwarg is accepted to keep backends that pass it positionally
+        working, but the value is discarded with a DeprecationWarning
+        — no property, no metadata carry-forward."""
         # No property at the class level.
         self.assertFalse(hasattr(type(Client(client_id=1, api_key="k")),
                                   "message_blacklist"))

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -419,5 +419,38 @@ class TestDeprecatedBlacklistShims(unittest.TestCase):
         self.assertEqual(deprecations, [])
 
 
+class TestAbstractDBRefresh(unittest.TestCase):
+    def test_refresh_returns_client_via_default_lookup(self):
+        db = _InMemoryDB()
+        db.add_item(Client(client_id=7, api_key="k", name="bob"))
+        got = db.refresh(7)
+        self.assertIsNotNone(got)
+        self.assertEqual(got.client_id, 7)
+
+    def test_refresh_returns_none_for_missing_id(self):
+        db = _InMemoryDB()
+        self.assertIsNone(db.refresh(99))
+
+    def test_refresh_none_id_returns_none(self):
+        db = _InMemoryDB()
+        self.assertIsNone(db.refresh(None))
+
+
+class TestAbstractDBForwardCompat(unittest.TestCase):
+    def test_forward_compat_raises_for_newer_schema(self):
+        db = _InMemoryDB()
+        with self.assertRaises(RuntimeError) as ctx:
+            db._check_forward_compat(999)
+        self.assertIn("999", str(ctx.exception))
+        self.assertIn("newer", str(ctx.exception))
+
+    def test_forward_compat_ok_for_equal_or_older(self):
+        db = _InMemoryDB()
+        target = getattr(_InMemoryDB, "SCHEMA_VERSION", 1)
+        # No exception expected.
+        db._check_forward_compat(target)
+        db._check_forward_compat(target - 1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,262 @@
+"""Tests for hivemind_plugin_manager.policy.
+
+Covers:
+- Mutation subclasses (apply behaviour + idempotency).
+- Verdict factories (allow / deny).
+- PolicyPlugin default behaviour (no-op allow + observe).
+- PolicyPluginFactory entry-point discovery.
+- Re-exports from the package top-level.
+"""
+from __future__ import annotations
+
+import dataclasses
+import unittest
+from unittest.mock import MagicMock, patch
+
+from hivemind_plugin_manager import (HiveMindPluginTypes, PolicyPlugin,
+                                     PolicyPluginFactory, Verdict)
+from hivemind_plugin_manager.policy import (AddBlacklistedIntent,
+                                            AddBlacklistedMessageType,
+                                            AddBlacklistedSkill, Mutation,
+                                            RewriteUtterance, SetContextField,
+                                            SetSessionField)
+
+
+class _FakeMessage:
+    """Minimal stand-in for ovos_bus_client.message.Message — just enough
+    surface for the Mutation tests. Avoids the bus_client dependency in
+    these unit tests."""
+
+    def __init__(self, msg_type="t", data=None, context=None):
+        self.msg_type = msg_type
+        self.data = data if data is not None else {}
+        self.context = context if context is not None else {}
+
+
+# ---------------------------------------------------------------------------
+# Verdict
+# ---------------------------------------------------------------------------
+
+class TestVerdictFactories(unittest.TestCase):
+    def test_allow_default(self):
+        v = Verdict.allow()
+        self.assertFalse(v.denied)
+        self.assertEqual(v.code, "")
+        self.assertEqual(v.mutations, [])
+
+    def test_allow_with_mutations(self):
+        m = AddBlacklistedSkill("foo")
+        v = Verdict.allow(m, AddBlacklistedIntent("bar"))
+        self.assertFalse(v.denied)
+        self.assertEqual(len(v.mutations), 2)
+        self.assertIs(v.mutations[0], m)
+
+    def test_deny_basic(self):
+        v = Verdict.deny("quota_exceeded")
+        self.assertTrue(v.denied)
+        self.assertEqual(v.code, "quota_exceeded")
+        self.assertEqual(v.reason, "")
+        self.assertEqual(v.data, {})
+
+    def test_deny_with_reason_and_data(self):
+        v = Verdict.deny("quota_exceeded", "daily limit reached",
+                         limit=100, used=100)
+        self.assertTrue(v.denied)
+        self.assertEqual(v.code, "quota_exceeded")
+        self.assertEqual(v.reason, "daily limit reached")
+        self.assertEqual(v.data, {"limit": 100, "used": 100})
+
+
+# ---------------------------------------------------------------------------
+# Mutations
+# ---------------------------------------------------------------------------
+
+class TestAddBlacklistedSkill(unittest.TestCase):
+    def test_creates_list_when_missing(self):
+        msg = _FakeMessage()
+        AddBlacklistedSkill("weather.skill").apply(msg, client=None)
+        self.assertEqual(
+            msg.context["session"]["blacklisted_skills"],
+            ["weather.skill"],
+        )
+
+    def test_appends_to_existing(self):
+        msg = _FakeMessage(context={"session": {"blacklisted_skills": ["a"]}})
+        AddBlacklistedSkill("b").apply(msg, client=None)
+        self.assertEqual(
+            msg.context["session"]["blacklisted_skills"], ["a", "b"],
+        )
+
+    def test_dedupes(self):
+        msg = _FakeMessage(context={"session": {"blacklisted_skills": ["a"]}})
+        AddBlacklistedSkill("a").apply(msg, client=None)
+        self.assertEqual(msg.context["session"]["blacklisted_skills"], ["a"])
+
+    def test_recovers_from_non_dict_session(self):
+        msg = _FakeMessage(context={"session": "garbage"})
+        AddBlacklistedSkill("x").apply(msg, client=None)
+        self.assertEqual(msg.context["session"], {"blacklisted_skills": ["x"]})
+
+    def test_recovers_from_non_dict_context(self):
+        msg = _FakeMessage(context="garbage")
+        AddBlacklistedSkill("x").apply(msg, client=None)
+        self.assertEqual(msg.context, {"session": {"blacklisted_skills": ["x"]}})
+
+
+class TestAddBlacklistedIntent(unittest.TestCase):
+    def test_dedupes_and_appends(self):
+        msg = _FakeMessage()
+        AddBlacklistedIntent("intent.a").apply(msg, client=None)
+        AddBlacklistedIntent("intent.b").apply(msg, client=None)
+        AddBlacklistedIntent("intent.a").apply(msg, client=None)
+        self.assertEqual(
+            msg.context["session"]["blacklisted_intents"],
+            ["intent.a", "intent.b"],
+        )
+
+
+class TestAddBlacklistedMessageType(unittest.TestCase):
+    def test_appends(self):
+        msg = _FakeMessage()
+        AddBlacklistedMessageType("speak").apply(msg, client=None)
+        self.assertEqual(
+            msg.context["session"]["blacklisted_message_types"], ["speak"],
+        )
+
+
+class TestSetSessionField(unittest.TestCase):
+    def test_sets_field(self):
+        msg = _FakeMessage()
+        SetSessionField("lang", "pt-pt").apply(msg, client=None)
+        self.assertEqual(msg.context["session"]["lang"], "pt-pt")
+
+    def test_overwrites_existing(self):
+        msg = _FakeMessage(context={"session": {"lang": "en-us"}})
+        SetSessionField("lang", "de-de").apply(msg, client=None)
+        self.assertEqual(msg.context["session"]["lang"], "de-de")
+
+
+class TestSetContextField(unittest.TestCase):
+    def test_sets_top_level_key(self):
+        msg = _FakeMessage()
+        SetContextField(("source",), "policy").apply(msg, client=None)
+        self.assertEqual(msg.context["source"], "policy")
+
+    def test_creates_nested_path(self):
+        msg = _FakeMessage()
+        SetContextField(("a", "b", "c"), 1).apply(msg, client=None)
+        self.assertEqual(msg.context["a"]["b"]["c"], 1)
+
+    def test_overwrites_non_dict_intermediate(self):
+        msg = _FakeMessage(context={"a": "scalar"})
+        SetContextField(("a", "b"), 1).apply(msg, client=None)
+        self.assertEqual(msg.context["a"], {"b": 1})
+
+    def test_empty_path_is_noop(self):
+        msg = _FakeMessage(context={"k": "v"})
+        SetContextField((), "anything").apply(msg, client=None)
+        self.assertEqual(msg.context, {"k": "v"})
+
+    def test_non_dict_context_is_replaced(self):
+        msg = _FakeMessage(context="garbage")
+        SetContextField(("k",), "v").apply(msg, client=None)
+        self.assertEqual(msg.context, {"k": "v"})
+
+
+class TestRewriteUtterance(unittest.TestCase):
+    def test_rewrites_recognizer_loop_utterance(self):
+        msg = _FakeMessage(
+            "recognizer_loop:utterance",
+            data={"utterances": ["old"], "lang": "en-us"},
+        )
+        RewriteUtterance("new").apply(msg, client=None)
+        self.assertEqual(msg.data["utterances"], ["new"])
+        self.assertEqual(msg.data["lang"], "en-us")  # unrelated fields preserved
+
+    def test_noop_for_other_msg_types(self):
+        msg = _FakeMessage("speak", data={"utterance": "hi"})
+        RewriteUtterance("new").apply(msg, client=None)
+        self.assertEqual(msg.data, {"utterance": "hi"})  # unchanged
+
+    def test_noop_when_data_is_not_dict(self):
+        msg = _FakeMessage("recognizer_loop:utterance", data=None)
+        msg.data = ["not", "a", "dict"]
+        RewriteUtterance("x").apply(msg, client=None)
+        self.assertEqual(msg.data, ["not", "a", "dict"])
+
+
+# ---------------------------------------------------------------------------
+# PolicyPlugin defaults
+# ---------------------------------------------------------------------------
+
+class TestPolicyPluginDefaults(unittest.TestCase):
+    def test_review_default_allows(self):
+        v = PolicyPlugin().review(_FakeMessage(), client=None)
+        self.assertFalse(v.denied)
+        self.assertEqual(v.mutations, [])
+
+    def test_review_binary_default_allows(self):
+        v = PolicyPlugin().review_binary(b"\x00\x01", client=None)
+        self.assertFalse(v.denied)
+
+    def test_observe_default_is_noop(self):
+        # Just verify it doesn't raise.
+        PolicyPlugin().observe(_FakeMessage(), client=None)
+
+    def test_is_subclass_of_sub_protocol(self):
+        from hivemind_plugin_manager.protocols import _SubProtocol
+        self.assertTrue(issubclass(PolicyPlugin, _SubProtocol))
+
+
+# ---------------------------------------------------------------------------
+# Plugin discovery via the hivemind.policy entry-point group
+# ---------------------------------------------------------------------------
+
+class TestPolicyPluginFactory(unittest.TestCase):
+    def test_get_class_raises_for_unknown_name(self):
+        with patch("hivemind_plugin_manager.find_plugins",
+                   return_value={}):
+            with self.assertRaises(KeyError):
+                PolicyPluginFactory.get_class("missing")
+
+    def test_get_class_returns_registered(self):
+        class _MyPolicy(PolicyPlugin):
+            pass
+
+        with patch("hivemind_plugin_manager.find_plugins",
+                   return_value={"my": _MyPolicy}):
+            self.assertIs(PolicyPluginFactory.get_class("my"), _MyPolicy)
+
+    def test_create_passes_config_and_hm_protocol(self):
+        class _MyPolicy(PolicyPlugin):
+            pass
+
+        with patch("hivemind_plugin_manager.find_plugins",
+                   return_value={"my": _MyPolicy}):
+            hm = MagicMock(name="hm_protocol")
+            plug = PolicyPluginFactory.create("my", config={"a": 1},
+                                              hm_protocol=hm)
+            self.assertIsInstance(plug, _MyPolicy)
+            self.assertEqual(plug.config, {"a": 1})
+            self.assertIs(plug.hm_protocol, hm)
+
+
+# ---------------------------------------------------------------------------
+# Re-exports + enum
+# ---------------------------------------------------------------------------
+
+class TestPackageReExports(unittest.TestCase):
+    def test_policy_types_exposed_at_top_level(self):
+        import hivemind_plugin_manager as pkg
+        for name in ("PolicyPlugin", "Verdict", "Mutation",
+                     "AddBlacklistedSkill", "AddBlacklistedIntent",
+                     "AddBlacklistedMessageType", "SetSessionField",
+                     "SetContextField", "RewriteUtterance"):
+            self.assertTrue(hasattr(pkg, name), f"missing top-level: {name}")
+
+    def test_policy_enum_value(self):
+        self.assertEqual(HiveMindPluginTypes.POLICY.value, "hivemind.policy")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,31 +1,28 @@
-"""Tests for hivemind_plugin_manager.policy.
+"""Tests for hivemind_plugin_manager.policy primitives.
 
 Covers:
-- Mutation subclasses (apply behaviour + idempotency).
 - Verdict factories (allow / deny).
 - PolicyPlugin default behaviour (no-op allow + observe).
 - PolicyPluginFactory entry-point discovery.
 - Re-exports from the package top-level.
+- Mutation ABC contract.
+
+Concrete mutation subclasses are agent-specific and live with their
+consumer (e.g. ``hivemind_ovos_agent_plugin.policy``); they are tested
+there.
 """
 from __future__ import annotations
 
-import dataclasses
 import unittest
 from unittest.mock import MagicMock, patch
 
-from hivemind_plugin_manager import (HiveMindPluginTypes, PolicyPlugin,
-                                     PolicyPluginFactory, Verdict)
-from hivemind_plugin_manager.policy import (AddBlacklistedIntent,
-                                            AddBlacklistedMessageType,
-                                            AddBlacklistedSkill, Mutation,
-                                            RewriteUtterance, SetContextField,
-                                            SetSessionField)
+from hivemind_plugin_manager import (HiveMindPluginTypes, Mutation,
+                                     PolicyPlugin, PolicyPluginFactory,
+                                     Verdict)
 
 
 class _FakeMessage:
-    """Minimal stand-in for ovos_bus_client.message.Message — just enough
-    surface for the Mutation tests. Avoids the bus_client dependency in
-    these unit tests."""
+    """Minimal stand-in for ovos_bus_client.message.Message."""
 
     def __init__(self, msg_type="t", data=None, context=None):
         self.msg_type = msg_type
@@ -45,11 +42,14 @@ class TestVerdictFactories(unittest.TestCase):
         self.assertEqual(v.mutations, [])
 
     def test_allow_with_mutations(self):
-        m = AddBlacklistedSkill("foo")
-        v = Verdict.allow(m, AddBlacklistedIntent("bar"))
+        class _M(Mutation):
+            def apply(self, message, client) -> None:
+                pass
+
+        m1, m2 = _M(), _M()
+        v = Verdict.allow(m1, m2)
         self.assertFalse(v.denied)
-        self.assertEqual(len(v.mutations), 2)
-        self.assertIs(v.mutations[0], m)
+        self.assertEqual(v.mutations, [m1, m2])
 
     def test_deny_basic(self):
         v = Verdict.deny("quota_exceeded")
@@ -68,121 +68,28 @@ class TestVerdictFactories(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# Mutations
+# Mutation ABC
 # ---------------------------------------------------------------------------
 
-class TestAddBlacklistedSkill(unittest.TestCase):
-    def test_creates_list_when_missing(self):
+class TestMutationABC(unittest.TestCase):
+    def test_cannot_instantiate_abstract(self):
+        with self.assertRaises(TypeError):
+            Mutation()
+
+    def test_subclass_must_implement_apply(self):
+        class _Incomplete(Mutation):
+            pass
+        with self.assertRaises(TypeError):
+            _Incomplete()
+
+    def test_concrete_subclass_works(self):
+        class _Concrete(Mutation):
+            def apply(self, message, client) -> None:
+                message.context["k"] = "v"
+
         msg = _FakeMessage()
-        AddBlacklistedSkill("weather.skill").apply(msg, client=None)
-        self.assertEqual(
-            msg.context["session"]["blacklisted_skills"],
-            ["weather.skill"],
-        )
-
-    def test_appends_to_existing(self):
-        msg = _FakeMessage(context={"session": {"blacklisted_skills": ["a"]}})
-        AddBlacklistedSkill("b").apply(msg, client=None)
-        self.assertEqual(
-            msg.context["session"]["blacklisted_skills"], ["a", "b"],
-        )
-
-    def test_dedupes(self):
-        msg = _FakeMessage(context={"session": {"blacklisted_skills": ["a"]}})
-        AddBlacklistedSkill("a").apply(msg, client=None)
-        self.assertEqual(msg.context["session"]["blacklisted_skills"], ["a"])
-
-    def test_recovers_from_non_dict_session(self):
-        msg = _FakeMessage(context={"session": "garbage"})
-        AddBlacklistedSkill("x").apply(msg, client=None)
-        self.assertEqual(msg.context["session"], {"blacklisted_skills": ["x"]})
-
-    def test_recovers_from_non_dict_context(self):
-        msg = _FakeMessage(context="garbage")
-        AddBlacklistedSkill("x").apply(msg, client=None)
-        self.assertEqual(msg.context, {"session": {"blacklisted_skills": ["x"]}})
-
-
-class TestAddBlacklistedIntent(unittest.TestCase):
-    def test_dedupes_and_appends(self):
-        msg = _FakeMessage()
-        AddBlacklistedIntent("intent.a").apply(msg, client=None)
-        AddBlacklistedIntent("intent.b").apply(msg, client=None)
-        AddBlacklistedIntent("intent.a").apply(msg, client=None)
-        self.assertEqual(
-            msg.context["session"]["blacklisted_intents"],
-            ["intent.a", "intent.b"],
-        )
-
-
-class TestAddBlacklistedMessageType(unittest.TestCase):
-    def test_appends(self):
-        msg = _FakeMessage()
-        AddBlacklistedMessageType("speak").apply(msg, client=None)
-        self.assertEqual(
-            msg.context["session"]["blacklisted_message_types"], ["speak"],
-        )
-
-
-class TestSetSessionField(unittest.TestCase):
-    def test_sets_field(self):
-        msg = _FakeMessage()
-        SetSessionField("lang", "pt-pt").apply(msg, client=None)
-        self.assertEqual(msg.context["session"]["lang"], "pt-pt")
-
-    def test_overwrites_existing(self):
-        msg = _FakeMessage(context={"session": {"lang": "en-us"}})
-        SetSessionField("lang", "de-de").apply(msg, client=None)
-        self.assertEqual(msg.context["session"]["lang"], "de-de")
-
-
-class TestSetContextField(unittest.TestCase):
-    def test_sets_top_level_key(self):
-        msg = _FakeMessage()
-        SetContextField(("source",), "policy").apply(msg, client=None)
-        self.assertEqual(msg.context["source"], "policy")
-
-    def test_creates_nested_path(self):
-        msg = _FakeMessage()
-        SetContextField(("a", "b", "c"), 1).apply(msg, client=None)
-        self.assertEqual(msg.context["a"]["b"]["c"], 1)
-
-    def test_overwrites_non_dict_intermediate(self):
-        msg = _FakeMessage(context={"a": "scalar"})
-        SetContextField(("a", "b"), 1).apply(msg, client=None)
-        self.assertEqual(msg.context["a"], {"b": 1})
-
-    def test_empty_path_is_noop(self):
-        msg = _FakeMessage(context={"k": "v"})
-        SetContextField((), "anything").apply(msg, client=None)
+        _Concrete().apply(msg, client=None)
         self.assertEqual(msg.context, {"k": "v"})
-
-    def test_non_dict_context_is_replaced(self):
-        msg = _FakeMessage(context="garbage")
-        SetContextField(("k",), "v").apply(msg, client=None)
-        self.assertEqual(msg.context, {"k": "v"})
-
-
-class TestRewriteUtterance(unittest.TestCase):
-    def test_rewrites_recognizer_loop_utterance(self):
-        msg = _FakeMessage(
-            "recognizer_loop:utterance",
-            data={"utterances": ["old"], "lang": "en-us"},
-        )
-        RewriteUtterance("new").apply(msg, client=None)
-        self.assertEqual(msg.data["utterances"], ["new"])
-        self.assertEqual(msg.data["lang"], "en-us")  # unrelated fields preserved
-
-    def test_noop_for_other_msg_types(self):
-        msg = _FakeMessage("speak", data={"utterance": "hi"})
-        RewriteUtterance("new").apply(msg, client=None)
-        self.assertEqual(msg.data, {"utterance": "hi"})  # unchanged
-
-    def test_noop_when_data_is_not_dict(self):
-        msg = _FakeMessage("recognizer_loop:utterance", data=None)
-        msg.data = ["not", "a", "dict"]
-        RewriteUtterance("x").apply(msg, client=None)
-        self.assertEqual(msg.data, ["not", "a", "dict"])
 
 
 # ---------------------------------------------------------------------------
@@ -246,13 +153,21 @@ class TestPolicyPluginFactory(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 class TestPackageReExports(unittest.TestCase):
-    def test_policy_types_exposed_at_top_level(self):
+    def test_primitives_exposed_at_top_level(self):
         import hivemind_plugin_manager as pkg
         for name in ("PolicyPlugin", "Verdict", "Mutation",
-                     "AddBlacklistedSkill", "AddBlacklistedIntent",
+                     "PolicyPluginFactory"):
+            self.assertTrue(hasattr(pkg, name), f"missing top-level: {name}")
+
+    def test_concrete_mutations_not_re_exported(self):
+        """Concrete OVOS-specific mutations now live in hivemind-ovos-agent-plugin."""
+        import hivemind_plugin_manager as pkg
+        for name in ("AddBlacklistedSkill", "AddBlacklistedIntent",
                      "AddBlacklistedMessageType", "SetSessionField",
                      "SetContextField", "RewriteUtterance"):
-            self.assertTrue(hasattr(pkg, name), f"missing top-level: {name}")
+            self.assertFalse(hasattr(pkg, name),
+                             f"{name} should not be re-exported by the "
+                             f"generic plugin-manager")
 
     def test_policy_enum_value(self):
         self.assertEqual(HiveMindPluginTypes.POLICY.value, "hivemind.policy")


### PR DESCRIPTION
## Summary

Adds the **admission-control primitives** specced in
[JarbasHiveMind/HiveMind-core#85](https://github.com/JarbasHiveMind/HiveMind-core/issues/85):
`PolicyPlugin` base class, typed `Verdict` return type, typed `Mutation` subclasses, plus
`PolicyPluginFactory` and the `hivemind.policy` entry-point group.

This is **the plugin-author surface only**. The chain runner that consumes these primitives
lives in `hivemind-core` and is the next PR in the sequence (Phase 0 of the #85 spec).

This PR is the clean implementation of the design the user and I agreed on after critiquing
the previous policy-plugin PR (#19, codex-style, still open) earlier in the planning thread.
Recommend closing #19 once this lands.

## What's new

### `hivemind_plugin_manager/policy.py`

- **`Mutation`** (abc) + six stdlib subclasses:
  | Class | Effect |
  |---|---|
  | `AddBlacklistedSkill(skill_id)` | Appends to `message.context["session"]["blacklisted_skills"]` (dedupe). |
  | `AddBlacklistedIntent(intent_name)` | Same shape for intents. |
  | `AddBlacklistedMessageType(msg_type)` | Same shape for message types. |
  | `SetSessionField(key, value)` | Set one key in the session dict. |
  | `SetContextField(path, value)` | Set a nested key in `message.context` (tuple-typed path). |
  | `RewriteUtterance(text)` | Replace `data["utterances"]` on `recognizer_loop:utterance` (silent no-op on other types). |

  Each `apply()` is idempotent on list mutations and **robust to non-dict context/session values** (it coerces). Source citations in the docstrings.

- **`Verdict`** dataclass:
  ```python
  Verdict.allow()                                    # no changes
  Verdict.allow(AddBlacklistedSkill("foo"), ...)     # allow + mutations
  Verdict.deny("quota_exceeded", "limit reached",    # stable code, reason, structured data
               limit=100, used=100)
  ```

- **`PolicyPlugin(_SubProtocol)`** with three **sync** hooks:
  - `review(message, client) -> Verdict` — before bus emit.
  - `review_binary(payload, client) -> Verdict` — for raw binary payloads. Default: allow.
  - `observe(message, client) -> None` — after a successful emit. Use for counters / audit / telemetry. Must not raise.

  Sync chosen deliberately — matches the rest of the `_SubProtocol` family and avoids needing a coordinated async change across `hivemind-plugin-manager`, `hivemind-core`, and every protocol implementer. Same reasoning [the user flagged earlier in this session](https://github.com/JarbasHiveMind/HiveMind-core/issues/85) when I tried to ship an async sidecar — there's no consumer for it.

### `hivemind_plugin_manager/__init__.py`

- New `HiveMindPluginTypes.POLICY = "hivemind.policy"` enum value.
- New `PolicyPluginFactory` mirroring the existing factories (`AgentProtocolFactory`, `NetworkProtocolFactory`, …).
- Top-level re-exports for `PolicyPlugin`, `Verdict`, `Mutation`, and all six stdlib mutation subclasses.

## Tests — `tests/test_policy.py` (30 tests, all passing)

- `Verdict.allow()` / `Verdict.deny()` factories with/without mutations, reason, data.
- Each `Mutation` subclass: happy path, dedup, missing-session creation, non-dict context recovery, no-op-when-not-applicable.
- `PolicyPlugin` defaults (review / review_binary allow; observe no-op).
- `PolicyPluginFactory` discovery via the `hivemind.policy` entry-point group + `KeyError` on unknown name.
- `HiveMindPluginTypes.POLICY` enum value.
- Top-level re-exports.

Full suite: **110 passed**, no regressions.

## Docs

- **`docs/plugins/policy.md`** — full plugin-author guide: hooks, Verdict, Mutation table, registration via entry points, a complete intent-quota example, factory usage. Cross-references HiveMind-core#85 for the consumer-side chain runner.
- **`docs/README.md`** — links the new guide alongside the other plugin-type guides.

## Versioning

Bump `0.5.0` → `0.6.0a1`. No breaking changes; adds an optional new plugin type.

## What this PR *does not* do

- **No chain runner.** That lives in `hivemind-core`. This PR ships only the primitives consumed by it.
- **No built-in policies.** `ClientACLPolicy` (the migration of static ACL enforcement out of `_update_blacklist` into a policy) lives in `hivemind-core`. `OVOSAgentPolicy` (skill/intent blacklists) lives in `ovos-agent-plugin`. Both are follow-up PRs once this lands.
- **No deny-message format**, no fail-closed semantics, no exception-to-`Verdict.deny("policy_error", ...)` mapping. All of that lives in the chain runner.

## Sequencing

1. **This PR** — policy primitives in `hivemind-plugin-manager` (~6 hours).
2. `hivemind-core` chain runner — three hook points (`_admit` before `bus.emit`, before binary forward, `observe` after emit), `client.user` cached on connection, `hive.policy.denied` response format, fail-closed semantics (~1–2 days).
3. `hivemind-core` `ClientACLPolicy` built-in — migrate `allowed_types` and `message_blacklist` checks out of `_update_blacklist` into a policy (~half a day).
4. `ovos-agent-plugin` `OVOSAgentPolicy` — migrate skill/intent blacklists into the chain (~half a day).

Total remaining after this PR: ~3 working days. Goldyfruit's plugins (`hivemind-intent-quota-policy`, etc.) are out of scope here.

## Refs

- Architecture spec: https://github.com/JarbasHiveMind/HiveMind-core/issues/85
- Supersedes the previous attempt at this surface, #19 in this repo (codex-style; recommend closing after this lands).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added policy plugin support (a fifth plugin type) for admission-control chains.
  * Introduced deny-by-default whitelist for client access via an `allowed_types` field.
  * Added database schema versioning with migration hooks.

* **Documentation**
  * New policy plugin guide plus updated API reference and concepts for plugin discovery and client model.

* **Deprecations**
  * Legacy blacklist fields deprecated with migration paths and warnings.

* **Tests**
  * Added unit and e2e tests covering policy behavior and blacklist migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->