### PR TITLE
fix(deps): bump json_database past the bundled-plugin versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 hivemind_bus_client
-json_database
+json_database>=0.10.2a1
 ovos-bus-client
 ovos-utils


### PR DESCRIPTION
json_database 0.9.1–0.10.1 register a `[hivemind.database] hivemind-json-db-plugin` entry point that collides with the standalone plugin's migration-capable JsonDB. Require `>=0.10.2a1` (which dropped the bundle).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version to improve application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->