### PR TITLE
feat: mandatory AgentProtocol.natural_language_query() streaming abc

### DIFF
--- a/hivemind_plugin_manager/protocols.py
+++ b/hivemind_plugin_manager/protocols.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import Dict, Any, Iterator, List, Union, Optional, Callable
 
 from ovos_bus_client import MessageBusClient
-from ovos_bus_client.message import Message
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG
 
@@ -88,61 +87,6 @@ class AgentProtocol(_SubProtocol, abc.ABC):
             ``str`` answer chunks, then a final ``None`` end-of-query sentinel.
         """
         raise NotImplementedError
-
-    def _stream_from_bus(self, utterance: str, lang: str,
-                         timeout: float = 10.0) -> Iterator[Optional[str]]:
-        """Reusable :meth:`natural_language_query` body for bus-backed agents:
-        inject the utterance under a fresh ``query_id`` (a query-scoped session,
-        so replies are correlated rather than reverse-routed to a satellite),
-        and stream the ``speak`` replies tagged with that id, ending on
-        ``ovos.utterance.handled`` or *timeout* inactivity. Yields each spoken
-        chunk, then a final ``None``.
-        """
-        import queue
-        import uuid
-
-        qid = uuid.uuid4().hex
-        q: "queue.Queue" = queue.Queue()
-
-        def _on_speak(msg):
-            if isinstance(msg, str):
-                try:
-                    msg = Message.deserialize(msg)
-                except Exception:
-                    return
-            if msg.msg_type == "speak" and msg.context.get("query_id") == qid:
-                q.put(msg.data.get("utterance", ""))
-
-        def _on_done(msg):
-            if isinstance(msg, str):
-                try:
-                    msg = Message.deserialize(msg)
-                except Exception:
-                    return
-            if msg.context.get("query_id") == qid:
-                q.put(None)
-
-        self.bus.on("speak", _on_speak)
-        self.bus.on("ovos.utterance.handled", _on_done)
-        try:
-            self.bus.emit(Message(
-                "recognizer_loop:utterance",
-                {"utterances": [utterance], "lang": lang},
-                {"query_id": qid, "session": {"session_id": qid}},
-            ))
-            while True:
-                try:
-                    chunk = q.get(timeout=timeout)
-                except queue.Empty:
-                    yield None
-                    return
-                if chunk is None:
-                    yield None
-                    return
-                yield chunk
-        finally:
-            self.bus.remove("speak", _on_speak)
-            self.bus.remove("ovos.utterance.handled", _on_done)
 
 @dataclass
 class NetworkProtocol(_SubProtocol):

--- a/hivemind_plugin_manager/protocols.py
+++ b/hivemind_plugin_manager/protocols.py
@@ -1,9 +1,10 @@
 import abc
 import dataclasses
 from dataclasses import dataclass
-from typing import Dict, Any, Union, Optional, Callable
+from typing import Dict, Any, Iterator, List, Union, Optional, Callable
 
 from ovos_bus_client import MessageBusClient
+from ovos_bus_client.message import Message
 from ovos_utils.fakebus import FakeBus
 from ovos_utils.log import LOG
 
@@ -58,13 +59,90 @@ class _SubProtocol:
 
 
 @dataclass
-class AgentProtocol(_SubProtocol):
+class AgentProtocol(_SubProtocol, abc.ABC):
     """protocol to handle Message objects, the payload of HiveMessage objects"""
     bus: Union[FakeBus, MessageBusClient] = dataclasses.field(default_factory=FakeBus)
     config: Dict[str, Any] = dataclasses.field(default_factory=dict)
     hm_protocol: Optional['HiveMindListenerProtocol'] = None # usually AgentProtocol is passed as kwarg to hm_protocol
                                                              # and only then assigned in hm_protocol.__post_init__
     callbacks: ClientCallbacks = dataclasses.field(default_factory=ClientCallbacks)
+
+    @abc.abstractmethod
+    def natural_language_query(self, utterance: str,
+                               lang: str) -> Iterator[Optional[str]]:
+        """Stream an answer to a natural-language query.
+
+        A generator: ``yield`` each answer chunk — the text of one ``speak`` —
+        as it is produced, then ``yield None`` once to signal end-of-query.
+        Yielding ``None`` immediately (no chunks) means the agent has no answer,
+        and the node escalates the query upstream instead of stalling.
+
+        Streaming lets a satellite start speaking the first sentence while the
+        rest is still being generated — an LLM/persona agent yields sentences as
+        the model produces them; an OVOS agent yields each ``speak`` as it lands
+        and ``None`` when the utterance is handled. This is the mandatory seam
+        hivemind-core's QUERY/CASCADE handlers consume, because *how* an agent
+        answers is backend-specific (a media-only agent just ``yield None``).
+
+        Yields:
+            ``str`` answer chunks, then a final ``None`` end-of-query sentinel.
+        """
+        raise NotImplementedError
+
+    def _stream_from_bus(self, utterance: str, lang: str,
+                         timeout: float = 10.0) -> Iterator[Optional[str]]:
+        """Reusable :meth:`natural_language_query` body for bus-backed agents:
+        inject the utterance under a fresh ``query_id`` (a query-scoped session,
+        so replies are correlated rather than reverse-routed to a satellite),
+        and stream the ``speak`` replies tagged with that id, ending on
+        ``ovos.utterance.handled`` or *timeout* inactivity. Yields each spoken
+        chunk, then a final ``None``.
+        """
+        import queue
+        import uuid
+
+        qid = uuid.uuid4().hex
+        q: "queue.Queue" = queue.Queue()
+
+        def _on_speak(msg):
+            if isinstance(msg, str):
+                try:
+                    msg = Message.deserialize(msg)
+                except Exception:
+                    return
+            if msg.msg_type == "speak" and msg.context.get("query_id") == qid:
+                q.put(msg.data.get("utterance", ""))
+
+        def _on_done(msg):
+            if isinstance(msg, str):
+                try:
+                    msg = Message.deserialize(msg)
+                except Exception:
+                    return
+            if msg.context.get("query_id") == qid:
+                q.put(None)
+
+        self.bus.on("speak", _on_speak)
+        self.bus.on("ovos.utterance.handled", _on_done)
+        try:
+            self.bus.emit(Message(
+                "recognizer_loop:utterance",
+                {"utterances": [utterance], "lang": lang},
+                {"query_id": qid, "session": {"session_id": qid}},
+            ))
+            while True:
+                try:
+                    chunk = q.get(timeout=timeout)
+                except queue.Empty:
+                    yield None
+                    return
+                if chunk is None:
+                    yield None
+                    return
+                yield chunk
+        finally:
+            self.bus.remove("speak", _on_speak)
+            self.bus.remove("ovos.utterance.handled", _on_done)
 
 @dataclass
 class NetworkProtocol(_SubProtocol):

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -13,6 +13,15 @@ from hivemind_plugin_manager.protocols import (
 )
 
 
+class _ConcreteAgent(AgentProtocol):
+    """Minimal concrete AgentProtocol for testing base infrastructure
+    (AgentProtocol is abstract — agent plugins must implement
+    natural_language_query)."""
+
+    def natural_language_query(self, utterance, lang):
+        yield None
+
+
 class TestModuleLevelCallbacks(unittest.TestCase):
     def test_callbacks_are_callable_and_return_none(self):
         # Each just logs and returns None; calling with a sentinel must not raise.
@@ -37,38 +46,38 @@ class TestClientCallbacks(unittest.TestCase):
         self.assertIs(cb.on_connect, f)
 
 
-class TestAgentProtocol(unittest.TestCase):
+class Test_ConcreteAgent(unittest.TestCase):
     def test_defaults(self):
-        p = AgentProtocol()
+        p = _ConcreteAgent()
         self.assertEqual(p.config, {})
         self.assertIsNone(p.hm_protocol)
         self.assertIsInstance(p.callbacks, ClientCallbacks)
 
     def test_identity_returns_new_when_no_hm_protocol(self):
-        p = AgentProtocol()
+        p = _ConcreteAgent()
         # NodeIdentity instantiable; just ensure property doesn't blow up
         self.assertIsNotNone(p.identity)
 
     def test_identity_delegates_to_hm_protocol(self):
         sentinel = object()
         hm = MagicMock(identity=sentinel)
-        p = AgentProtocol(hm_protocol=hm)
+        p = _ConcreteAgent(hm_protocol=hm)
         self.assertIs(p.identity, sentinel)
 
     def test_database_none_when_no_hm_protocol(self):
-        self.assertIsNone(AgentProtocol().database)
+        self.assertIsNone(_ConcreteAgent().database)
 
     def test_database_delegates_to_hm_protocol(self):
         sentinel = object()
         hm = MagicMock(db=sentinel)
-        self.assertIs(AgentProtocol(hm_protocol=hm).database, sentinel)
+        self.assertIs(_ConcreteAgent(hm_protocol=hm).database, sentinel)
 
     def test_clients_empty_when_no_hm_protocol(self):
-        self.assertEqual(AgentProtocol().clients, {})
+        self.assertEqual(_ConcreteAgent().clients, {})
 
     def test_clients_delegates_to_hm_protocol(self):
         hm = MagicMock(clients={"a": 1})
-        self.assertEqual(AgentProtocol(hm_protocol=hm).clients, {"a": 1})
+        self.assertEqual(_ConcreteAgent(hm_protocol=hm).clients, {"a": 1})
 
 
 class TestNetworkProtocol(unittest.TestCase):


### PR DESCRIPTION
Adds a mandatory natural_language_query(utterance, lang) -> Iterator[Optional[str]] abstractmethod to AgentProtocol (now abc.ABC): yields answer chunks (one per speak) then a final None end-of-query sentinel. The seam hivemind-core QUERY/CASCADE consume. Ships a reusable _stream_from_bus helper (injects under a fresh query-scoped session so replies are correlated, not reverse-routed). Companion PRs implement it per agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added streaming support for agent responses, enabling incremental delivery of response content for improved responsiveness and real-time interaction experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->