### PR TITLE
fix: Client.message_blacklist no-op read shim (AttributeError on read)

### DIFF
--- a/hivemind_plugin_manager/database.py
+++ b/hivemind_plugin_manager/database.py
@@ -115,11 +115,28 @@ class Client:
         else:
             self.metadata.pop("intent_blacklist", None)
 
-    # message_blacklist is not part of the data model. No property
-    # shim and no metadata carry-forward; deserialize strips the
-    # top-level key silently, the kwarg path discards the value with
-    # a DeprecationWarning but the kwarg itself is accepted so
-    # backends passing it positionally don't crash.
+    # message_blacklist is not part of the data model and carries no
+    # value: deserialize strips the top-level key and the kwarg path
+    # discards it (see _client_init_with_legacy_kwargs). The read shim
+    # below keeps `client.message_blacklist` working as a no-op for
+    # legacy readers — it always returns [] and warns — so callers that
+    # still reference it (older protocol plugins) don't crash.
+    @property
+    def message_blacklist(self) -> List[str]:
+        warnings.warn(
+            "Client.message_blacklist is removed and ignored; hivemind-core "
+            "is whitelist-only (use allowed_types). This shim returns [].",
+            DeprecationWarning, stacklevel=2,
+        )
+        return []
+
+    @message_blacklist.setter
+    def message_blacklist(self, value):
+        warnings.warn(
+            "Client.message_blacklist is removed and ignored; hivemind-core "
+            "is whitelist-only (use allowed_types). Setting it has no effect.",
+            DeprecationWarning, stacklevel=2,
+        )
 
     def serialize(self) -> str:
         """

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -292,14 +292,21 @@ class TestDeprecatedBlacklistShims(unittest.TestCase):
         self.assertEqual(c.skill_blacklist, [])
         self.assertEqual(c.intent_blacklist, [])
 
-    def test_message_blacklist_kwarg_accepted_but_discarded(self):
-        """``message_blacklist`` is not part of the data model. The
-        kwarg is accepted to keep backends that pass it positionally
-        working, but the value is discarded with a DeprecationWarning
-        — no property, no metadata carry-forward."""
-        # No property at the class level.
-        self.assertFalse(hasattr(type(Client(client_id=1, api_key="k")),
-                                  "message_blacklist"))
+    def test_message_blacklist_noop_shim(self):
+        """``message_blacklist`` is removed from the data model. A no-op read
+        shim keeps legacy readers (older protocol plugins) working: it always
+        returns [] and warns. The constructor kwarg is accepted but discarded
+        with a DeprecationWarning — no metadata carry-forward."""
+        # Read shim exists at the class level and returns [] with a warning.
+        self.assertTrue(hasattr(type(Client(client_id=1, api_key="k")),
+                                 "message_blacklist"))
+        ctx, caught = self._catch_warnings()
+        try:
+            val = Client(client_id=1, api_key="k").message_blacklist
+        finally:
+            ctx.__exit__(None, None, None)
+        self.assertEqual(val, [])
+        self._assert_has_deprecation(caught, "message_blacklist")
         # Constructor kwarg is accepted but emits a warning and
         # discards the value — NOT carried into metadata.
         ctx, caught = self._catch_warnings()


### PR DESCRIPTION
#85's blacklist refactor removed the `message_blacklist` field and added read shims for `skill_blacklist`/`intent_blacklist` — but **not** `message_blacklist`. So `client.message_blacklist` raised `AttributeError`, crashing protocol plugins (websocket/http/mqtt) that read it during auth (the band-aid PRs JarbasHiveMind/hivemind-websocket-protocol#27 / hivemind-http-protocol#12 worked around this).

Adds the missing no-op read shim: always returns `[]` and warns (`DeprecationWarning`), consistent with the other two. Construction/deserialize keep discarding the value. The protocol plugins drop the read entirely in their own PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * `message_blacklist` property is now deprecated. Accessing it will emit a deprecation warning and has no effect. Plan to remove usage as this will be fully removed in a future release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->