### PR TITLE
feat: add get_bus/answer_query agent hooks for per-tenant routing

### DIFF
--- a/hivemind_plugin_manager/protocols.py
+++ b/hivemind_plugin_manager/protocols.py
@@ -88,6 +88,31 @@ class AgentProtocol(_SubProtocol, abc.ABC):
         """
         raise NotImplementedError
 
+    def get_bus(self, client: Optional['HiveMindClientConnection'] = None
+                ) -> Union[FakeBus, MessageBusClient]:
+        """Return the bus a given client's injected messages should land on.
+
+        Default: the single shared agent bus. A *multiplexing* agent (e.g. one
+        isolated brain per access key) overrides this to return a per-client
+        bus; ``hivemind-core`` calls it for every injected message, so per-key
+        routing on the inject path stays transparent and needs no peer-sniffing.
+        """
+        return self.bus
+
+    def answer_query(self, utterance: str, lang: str,
+                     client: Optional['HiveMindClientConnection'] = None
+                     ) -> Iterator[Optional[str]]:
+        """Context-aware entry point for the QUERY/CASCADE streaming path.
+
+        ``natural_language_query`` is the backend primitive (utterance + lang,
+        no caller identity). ``answer_query`` is what ``hivemind-core`` calls,
+        additionally passing the originating ``client`` so a multiplexing agent
+        can dispatch to the right per-key sub-agent. The default ignores the
+        client and delegates to ``natural_language_query``, so existing agents
+        need no changes.
+        """
+        yield from self.natural_language_query(utterance, lang)
+
 @dataclass
 class NetworkProtocol(_SubProtocol):
     """protocol to transport HiveMessage objects around"""

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -79,6 +79,45 @@ class Test_ConcreteAgent(unittest.TestCase):
         hm = MagicMock(clients={"a": 1})
         self.assertEqual(_ConcreteAgent(hm_protocol=hm).clients, {"a": 1})
 
+    def test_get_bus_defaults_to_shared_bus(self):
+        # Default hook: every client shares the one agent bus.
+        p = _ConcreteAgent()
+        self.assertIs(p.get_bus(client=object()), p.bus)
+        self.assertIs(p.get_bus(), p.bus)
+
+    def test_answer_query_defaults_to_natural_language_query(self):
+        # Default hook ignores client and delegates to the NLQ primitive.
+        p = _ConcreteAgent()
+        self.assertEqual(list(p.answer_query("hello", "en-us", client=object())),
+                         [None])
+
+
+class TestMultiplexingAgentOverrides(unittest.TestCase):
+    """A multiplexing agent (one sub-agent per access key) overrides the
+    default hooks to route by client — the seam MultiMind relies on."""
+
+    def test_get_bus_and_answer_query_route_per_client(self):
+        buses = {"key-a": object(), "key-b": object()}
+
+        class _Mux(AgentProtocol):
+            def natural_language_query(self, utterance, lang):
+                yield None  # unused; routing happens in answer_query
+
+            def get_bus(self, client=None):
+                return buses[client.key]
+
+            def answer_query(self, utterance, lang, client=None):
+                yield f"{client.key}:{utterance}"
+                yield None
+
+        mux = _Mux()
+        self.assertIs(mux.get_bus(MagicMock(key="key-a")), buses["key-a"])
+        self.assertIs(mux.get_bus(MagicMock(key="key-b")), buses["key-b"])
+        self.assertEqual(
+            list(mux.answer_query("hi", "en-us", client=MagicMock(key="key-b"))),
+            ["key-b:hi", None],
+        )
+
 
 class TestNetworkProtocol(unittest.TestCase):
     def test_agent_protocol_none_when_no_hm_protocol(self):


### PR DESCRIPTION
Adds two default-implemented hooks to `AgentProtocol` so a *multiplexing* agent (one isolated sub-agent per access key) can route by client, without changing the `natural_language_query` primitive every backend implements:

- `get_bus(client)` — default returns the shared bus; override for a per-key bus (inject path).
- `answer_query(utterance, lang, client)` — default delegates to `natural_language_query`; override to dispatch per-key (QUERY/CASCADE path).

Existing agents (ovos, a2a, persona, media-player, hivescope) inherit both unchanged — zero blast radius.

Paired with HiveMind-core PR that routes through these hooks. Enables the upcoming MultiMind per-key agent multiplexer.

Tests: `tests/test_protocols.py` covers both defaults + a multiplexing override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)